### PR TITLE
Backport QUADS fixes to upstream badfish.

### DIFF
--- a/badfish.py
+++ b/badfish.py
@@ -6,7 +6,6 @@ from requests.exceptions import RequestException
 
 import json
 import argparse
-import logging
 import os
 import re
 import requests
@@ -18,6 +17,7 @@ import yaml
 warnings.filterwarnings("ignore")
 
 RETRIES = 15
+
 
 class Badfish:
     def __init__(self, _host, _username, _password, logger, _retries=RETRIES):
@@ -63,10 +63,10 @@ class Badfish:
         try:
             _response = requests.get(uri, auth=(self.username, self.password), verify=False, timeout=60)
         except RequestException:
-           self.logger.exception("Failed to communicate with server.")
-           if _continue:
-               return
-           else:
+            self.logger.exception("Failed to communicate with server.")
+            if _continue:
+                return
+            else:
                 sys.exit(1)
         return _response
 
@@ -398,7 +398,7 @@ class Badfish:
         _url = "%s/Dell/Managers/iDRAC.Embedded.1/DellJobService/" % self.root_uri
         _response = self.get_request(_url)
         if _response.status_code != 200:
-            logger.warning("iDRAC version installed does not support DellJobService")
+            self.logger.warning("iDRAC version installed does not support DellJobService")
             return False
 
         return True
@@ -417,16 +417,16 @@ class Badfish:
     def clear_job_list(self, _job_queue):
         _url = "%s%s/Jobs" % (self.host_uri, self.manager_resource)
         _headers = {"content-type": "application/json"}
-        logger.warning("Clearing job queue for job IDs: %s." % _job_queue)
+        self.logger.warning("Clearing job queue for job IDs: %s." % _job_queue)
         for _job in _job_queue:
             job = _job.strip("'")
-            url = "%s/%s" % (_url, job)
+            url = "/".join([_url, job])
             self.delete_request(url, _headers)
         job_queue = self.get_job_queue()
         if not job_queue:
-            logger.info("Job queue for iDRAC %s successfully cleared." % self.host)
+            self.logger.info("Job queue for iDRAC %s successfully cleared." % self.host)
         else:
-            logger.error("Job queue not cleared, current job queue contains jobs: %s." % job_queue)
+            self.logger.error("Job queue not cleared, current job queue contains jobs: %s." % job_queue)
             sys.exit(1)
 
     def clear_job_queue(self):
@@ -581,7 +581,6 @@ class Badfish:
                     self.clear_job_queue()
                     if not _first_reset:
                         self.reset_idrac()
-                        _self_reset = True
                         self.polling_host_state("On")
                     continue
                 self.error_handler(_response)

--- a/badfish.py
+++ b/badfish.py
@@ -411,7 +411,7 @@ class Badfish:
         if response.status_code == 200:
             self.logger.info("Job queue for iDRAC %s successfully cleared." % self.host)
         else:
-            logger.error("Job queue not cleared, there was something wrong with your request.")
+            self.logger.error("Job queue not cleared, there was something wrong with your request.")
             sys.exit(1)
 
     def clear_job_list(self, _job_queue):

--- a/badfish.py
+++ b/badfish.py
@@ -390,7 +390,7 @@ class Badfish:
         if _response.status_code == 200:
             self.logger.info('PATCH command passed to set next boot onetime boot device to: "%s".' % "Pxe")
         else:
-            logger.error("Command failed, error code is %s." % _response.status_code)
+            self.logger.error("Command failed, error code is %s." % _response.status_code)
 
             self.error_handler(_response)
 

--- a/badfish.py
+++ b/badfish.py
@@ -388,7 +388,7 @@ class Badfish:
         time.sleep(5)
 
         if _response.status_code == 200:
-            logger.info('PATCH command passed to set next boot onetime boot device to: "%s".' % "Pxe")
+            self.logger.info('PATCH command passed to set next boot onetime boot device to: "%s".' % "Pxe")
         else:
             logger.error("Command failed, error code is %s." % _response.status_code)
 
@@ -409,7 +409,7 @@ class Badfish:
         _headers = {'content-type': 'application/json'}
         response = self.post_request(_url, _payload, _headers)
         if response.status_code == 200:
-            logger.info("Job queue for iDRAC %s successfully cleared." % self.host)
+            self.logger.info("Job queue for iDRAC %s successfully cleared." % self.host)
         else:
             logger.error("Job queue not cleared, there was something wrong with your request.")
             sys.exit(1)

--- a/tests/config.py
+++ b/tests/config.py
@@ -96,7 +96,11 @@ RESPONSE_CHANGE_BOOT = "- INFO     - Systems service: /redfish/v1/Systems/System
                        "- INFO     - POST command passed to create target config job.\n" \
                        "- INFO     - JID_498218641680 job ID successfully created.\n" \
                        "- INFO     - Command passed to check job status, code 200 returned.\n" \
-                       "- INFO     - Job id JID_498218641680 successfully scheduled.\n"
+                       "- INFO     - Job id JID_498218641680 successfully scheduled.\n" \
+                       "- INFO     - Status code 204 returned for POST command to reset iDRAC.\n" \
+                       "- INFO     - iDRAC will now reset and be back online within a few minutes.\n" \
+                       "- INFO     - Polling for host state: On\n" \
+                       "- INFO     - Command passed to On server, code return is 204.\n" \
 
 RESPONSE_CHANGE_NO_INT = "- INFO     - Systems service: /redfish/v1/Systems/System.Embedded.1.\n" \
                          "- INFO     - Managers service: /redfish/v1/Managers/iDRAC.Embedded.1.\n" \


### PR DESCRIPTION
This backports the following patches from the badfish QUADS library back
to upstream, standalone badfish and also updates the python tests.

https://github.com/redhat-performance/quads/commit/41f7390caf1106072552c0e7f3aa53812df48635
https://github.com/redhat-performance/quads/commit/43712d2cbdc0978c1dbd0c63f77775dffe513899