### PR TITLE
Fix for double reboot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
          * [Forcing a one time boot to a specific device](#forcing-a-one-time-boot-to-a-specific-device)
          * [Forcing a one-time boot to PXE](#forcing-a-one-time-boot-to-pxe)
          * [Rebooting a System](#rebooting-a-system)
+         * [Power Cycling a System](#power-cycling-a-system)
          * [Resetting iDRAC](#resetting-idrac)
          * [Check current boot order](#check-current-boot-order)
          * [Variable number of retries](#variable-number-of-retries)
@@ -101,6 +102,12 @@ To force systems to perform a one-time boot to PXE, simply pass the ```--pxe``` 
 In certain cases you might need to only reboot the host, for this case we included the ```--reboot-only``` flag which will force a GracefulRestart on the target host. Note that this option is not to be used with any other option.
 ```
 ./badfish.py -H mgmt-your-server.example.com -u root -p yourpass --reboot-only
+```
+
+### Power cycling a system
+For a hard reset you can use ```--power-cycle``` flag which will run a ForceOff instruction on the target host. Note that this option is not to be used with any other option.
+```
+./badfish.py -H mgmt-your-server.example.com -u root -p yourpass --power-cycle
 ```
 
 ### Resetting iDRAC

--- a/badfish.py
+++ b/badfish.py
@@ -495,13 +495,9 @@ class Badfish:
             if graceful:
                 self.send_reset("GracefulRestart")
 
-                host_down = self.polling_host_state("Off")
-
-                if not host_down:
-                    self.logger.warning(
-                        "Unable to graceful shutdown the server, will perform forced shutdown now."
-                    )
-                    self.send_reset("ForceOff")
+                self.logger.warning(
+                    "Graceful shutdown executed. This might take a few minutes."
+                )
             else:
                 self.send_reset("ForceOff")
 
@@ -742,6 +738,7 @@ def execute_badfish(_host, _args, logger):
     device = _args["boot_to"]
     boot_to_type = _args["boot_to_type"]
     reboot_only = _args["reboot_only"]
+    power_cycle = _args["power_cycle"]
     racreset = _args["racreset"]
     check_boot = _args["check_boot"]
     firmware_inventory = _args["firmware_inventory"]
@@ -756,6 +753,8 @@ def execute_badfish(_host, _args, logger):
 
     if reboot_only:
         badfish.reboot_server()
+    elif power_cycle:
+        badfish.reboot_server(graceful=False)
     elif racreset:
         badfish.reset_idrac()
     elif device:
@@ -793,6 +792,7 @@ def main(argv=None):
     parser.add_argument("--boot-to", help="Set next boot to one-shot boot to a specific device")
     parser.add_argument("--boot-to-type", help="Set next boot to one-shot boot to either director or foreman")
     parser.add_argument("--reboot-only", help="Flag for only rebooting the host", action="store_true")
+    parser.add_argument("--power-cycle", help="Flag for sending ForceOff instruction to the host", action="store_true")
     parser.add_argument("--racreset", help="Flag for iDRAC reset", action="store_true")
     parser.add_argument("--check-boot", help="Flag for checking the host boot order", action="store_true")
     parser.add_argument("--firmware-inventory", help="Get firmware inventory", action="store_true")

--- a/tests/config.py
+++ b/tests/config.py
@@ -75,7 +75,7 @@ RESPONSE_BOOT_TO = "- INFO     - Systems service: /redfish/v1/Systems/System.Emb
 RESPONSE_REBOOT_ONLY_SUCCESS = "- INFO     - Systems service: /redfish/v1/Systems/System.Embedded.1.\n" \
                                "- INFO     - Managers service: /redfish/v1/Managers/iDRAC.Embedded.1.\n" \
                                "- INFO     - Command passed to GracefulRestart server, code return is 204.\n" \
-                               "- INFO     - Polling for host state: Off\n" \
+                               "- WARNING  - Graceful shutdown executed. This might take a few minutes.\n" \
                                "- INFO     - Polling for host state: Not Down\n" \
                                "- INFO     - Command passed to On server, code return is 204.\n"
 


### PR DESCRIPTION
Added --power-cycle which in contrast to reboot-only does a force
off instruction instead of a graceful reset.
Removed host status polling for reboot-only.

Fixes: https://github.com/redhat-performance/badfish/issues/40