### PR TITLE
Update r740xd bios boot strings

### DIFF
--- a/config/idrac_interfaces.yml
+++ b/config/idrac_interfaces.yml
@@ -9,20 +9,14 @@ director_630_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Slot.2-1-1
 director_640_interfaces: NIC.Slot.3-1,HardDisk.List.1-1,NIC.Slot.3-2,NIC.Slot.2-1,NIC.Slot.2-2,NIC.Integrated.1-1-1
 director_720xd_interfaces: NIC.Slot.4-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
 director_730xd_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
-<<<<<<< HEAD
 director_740xd_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-3-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
-=======
 director_740xd_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-3-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1,NIC.Integrated.1-4-1
->>>>>>> 419eb31d7f6508c0527977f0e6670e415e869e7f
 director_930_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
 foreman_620_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Slot.2-4,NIC.Slot.2-1,NIC.Slot.2-2,NIC.Slot.2-3
 foreman_630_interfaces: NIC.Slot.2-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
 foreman_640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1,NIC.Slot.3-2,NIC.Slot.2-1,NIC.Slot.2-2
 foreman_720xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Slot.4-2-1
 foreman_730xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
-<<<<<<< HEAD
 foreman_740xd_interfaces: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
-=======
 foreman_740xd_interfaces: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1,NIC.Integrated.1-4-1
->>>>>>> 419eb31d7f6508c0527977f0e6670e415e869e7f
 foreman_930_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1

--- a/config/idrac_interfaces.yml
+++ b/config/idrac_interfaces.yml
@@ -9,12 +9,20 @@ director_630_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Slot.2-1-1
 director_640_interfaces: NIC.Slot.3-1,HardDisk.List.1-1,NIC.Slot.3-2,NIC.Slot.2-1,NIC.Slot.2-2,NIC.Integrated.1-1-1
 director_720xd_interfaces: NIC.Slot.4-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
 director_730xd_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
+<<<<<<< HEAD
+director_740xd_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-3-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
+=======
 director_740xd_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-3-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1,NIC.Integrated.1-4-1
+>>>>>>> 419eb31d7f6508c0527977f0e6670e415e869e7f
 director_930_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
 foreman_620_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Slot.2-4,NIC.Slot.2-1,NIC.Slot.2-2,NIC.Slot.2-3
 foreman_630_interfaces: NIC.Slot.2-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
 foreman_640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1,NIC.Slot.3-2,NIC.Slot.2-1,NIC.Slot.2-2
 foreman_720xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Slot.4-2-1
 foreman_730xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
+<<<<<<< HEAD
+foreman_740xd_interfaces: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
+=======
 foreman_740xd_interfaces: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1,NIC.Integrated.1-4-1
+>>>>>>> 419eb31d7f6508c0527977f0e6670e415e869e7f
 foreman_930_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1

--- a/config/idrac_interfaces.yml
+++ b/config/idrac_interfaces.yml
@@ -10,7 +10,6 @@ director_640_interfaces: NIC.Slot.3-1,HardDisk.List.1-1,NIC.Slot.3-2,NIC.Slot.2-
 director_720xd_interfaces: NIC.Slot.4-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
 director_730xd_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
 director_740xd_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-3-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
-director_740xd_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-3-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1,NIC.Integrated.1-4-1
 director_930_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
 foreman_620_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Slot.2-4,NIC.Slot.2-1,NIC.Slot.2-2,NIC.Slot.2-3
 foreman_630_interfaces: NIC.Slot.2-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
@@ -18,5 +17,4 @@ foreman_640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1,NIC.
 foreman_720xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Slot.4-2-1
 foreman_730xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
 foreman_740xd_interfaces: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
-foreman_740xd_interfaces: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1,NIC.Integrated.1-4-1
 foreman_930_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1

--- a/config/idrac_interfaces.yml
+++ b/config/idrac_interfaces.yml
@@ -9,12 +9,12 @@ director_630_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Slot.2-1-1
 director_640_interfaces: NIC.Slot.3-1,HardDisk.List.1-1,NIC.Slot.3-2,NIC.Slot.2-1,NIC.Slot.2-2,NIC.Integrated.1-1-1
 director_720xd_interfaces: NIC.Slot.4-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
 director_730xd_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
-director_740xd_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
+director_740xd_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-3-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1,NIC.Integrated.1-4-1
 director_930_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
 foreman_620_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Slot.2-4,NIC.Slot.2-1,NIC.Slot.2-2,NIC.Slot.2-3
 foreman_630_interfaces: NIC.Slot.2-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
 foreman_640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1,NIC.Slot.3-2,NIC.Slot.2-1,NIC.Slot.2-2
 foreman_720xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Slot.4-2-1
 foreman_730xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
-foreman_740xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+foreman_740xd_interfaces: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1,NIC.Integrated.1-4-1
 foreman_930_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1


### PR DESCRIPTION
Update idrac_interfaces.yml key/value pairs to match recent changes to
interfaces in the ALIAS R&D environment.

Related-to: https://github.com/redhat-performance/badfish/issues/56