### PR TITLE
support added for blades

### DIFF
--- a/badfish.py
+++ b/badfish.py
@@ -219,6 +219,9 @@ class Badfish:
                     sys.exit(1)
 
             host_model = self.host.split(".")[0].split("-")[-1]
+            host_blade = self.host.split(".")[0].split("-")[-2]
+            if host_blade != "000":
+                host_model = "%s_%s" % (host_model, host_blade)
             if host_model.startswith("r"):
                 host_model = host_model[1:]
             for _host in ["foreman", "director"]:
@@ -388,6 +391,9 @@ class Badfish:
                 sys.exit(1)
 
         host_model = self.host.split(".")[0].split("-")[-1]
+        host_blade = self.host.split(".")[0].split("-")[-2]
+        if host_blade != "000":
+            host_model = "%s_%s" % (host_model, host_blade)
         if host_model.startswith("r"):
             host_model = host_model[1:]
         interfaces = definitions["%s_%s_interfaces" % (_host_type, host_model)].split(",")
@@ -817,6 +823,9 @@ class Badfish:
                     sys.exit(1)
 
             host_model = self.host.split(".")[0].split("-")[-1]
+            host_blade = self.host.split(".")[0].split("-")[-2]
+            if host_blade != "000":
+                host_model = "%s_%s" % (host_model, host_blade)
             if host_model.startswith("r"):
                 host_model = host_model[1:]
             return definitions["%s_%s_interfaces" % (host_type, host_model)].split(",")[0]

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,6 +1,6 @@
 import os
 
-MOCK_HOST = "r630.host.io"
+MOCK_HOST = "r630.000.host.io"
 MOCK_USER = "mock_user"
 MOCK_PASS = "mock_pass"
 


### PR DESCRIPTION
This is related to a patch submitted in related project
quads.  See:

   https://review.gerrithub.io/c/redhat-performance/quads/+/486939

assuming the naming convention is followed as :

  rack-uloc-blade-type.domain

where "blade" would be 000 for single system chassis systems,
while for bladecenters such as the fx2 chassis from Dell would
use values of "b01", "b02", etc.  This patch will extend the
idrac_interfaces lookups to differentiate between each blade
and will require a distinct entry for each for the "foreman"
and "director" types.  For example, if you have hosts with these
names:

  f01-h20-b01-fc640.example.com
  f01-h20-b02-fc640.example.com

Then you will also likely want to have the following entries
in your idrac_interfaces.yml file:

director_fc640_b01_interfaces: NIC.ChassisSlot.8-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
director_fc640_b02_interfaces: NIC.ChassisSlot.4-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
foreman_fc640_b01_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.ChassisSlot.8-1-1
foreman_fc640_b02_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.ChassisSlot.4-1-1

the reason is that the shared IO modules map interfaces to different
PCI slots from the host perspective, and as such the boot devices
will be different depending on which blade you're working with.

If the hostname contains the 000 instead, then we don't alter the
director and foreman entries (i.e. no suffix is added).