### PR TITLE
fix hostname parsing for blades

### DIFF
--- a/badfish.py
+++ b/badfish.py
@@ -220,7 +220,8 @@ class Badfish:
 
             host_model = self.host.split(".")[0].split("-")[-1]
             host_blade = self.host.split(".")[0].split("-")[-2]
-            if host_blade != "000":
+            b_pattern = re.compile("b0[0-9]")
+            if b_pattern.match(host_blade):
                 host_model = "%s_%s" % (host_model, host_blade)
             if host_model.startswith("r"):
                 host_model = host_model[1:]
@@ -392,7 +393,8 @@ class Badfish:
 
         host_model = self.host.split(".")[0].split("-")[-1]
         host_blade = self.host.split(".")[0].split("-")[-2]
-        if host_blade != "000":
+        b_pattern = re.compile("b0[0-9]")
+        if b_pattern.match(host_blade):
             host_model = "%s_%s" % (host_model, host_blade)
         if host_model.startswith("r"):
             host_model = host_model[1:]
@@ -824,7 +826,8 @@ class Badfish:
 
             host_model = self.host.split(".")[0].split("-")[-1]
             host_blade = self.host.split(".")[0].split("-")[-2]
-            if host_blade != "000":
+            b_pattern = re.compile("b0[0-9]")
+            if b_pattern.match(host_blade):
                 host_model = "%s_%s" % (host_model, host_blade)
             if host_model.startswith("r"):
                 host_model = host_model[1:]


### PR DESCRIPTION
This fixes an unintended consequence of a previous patch
that parses the hostname in order to determine what to look
for in the idrac_interfaces.yml file.

Now to designate a blade (e.g. fc640), the hostname will need
to be of the form:

<x>-<y>-b0[0-9]-model