### PR TITLE
Alias lab AMD server support

### DIFF
--- a/config/idrac_interfaces.yml
+++ b/config/idrac_interfaces.yml
@@ -13,6 +13,8 @@ director_r640_interfaces: NIC.Slot.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
 director_r720xd_interfaces: NIC.Slot.4-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
 director_r730xd_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
 director_740xd_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,NIC.Integrated.1-3-1,HardDisk.List.1-1
+director_7425_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,NIC.Integrated.1-3-1,HardDisk.List.1-1
+director_7525_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.6-2-1,NIC.Slot.6-1-1,NIC.Embedded.1-1-1,HardDisk.List.1-1
 director_r930_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
 foreman_r620_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Slot.2-4,NIC.Slot.2-1,NIC.Slot.2-2,NIC.Slot.2-3
 foreman_r630_interfaces: NIC.Slot.2-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
@@ -24,6 +26,8 @@ foreman_r640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.1-2-1
 foreman_r720xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Slot.4-2-1
 foreman_r730xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
 foreman_740xd_interfaces: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
+foreman_7425_interfaces: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1
+foreman_7525_interfaces: NIC.Embedded.1-1-1,NIC.Integrated.1-1-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,HardDisk.List.1-1
 foreman_r930_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
 
 # Custom Rack F04


### PR DESCRIPTION
Do not merge yet, needs some more testing, although badfish accepts this file as syntactically correct.

This change was suggested by Chris Enright to support the new AMD servers in the Alias lab.  I came across this problem because these servers were assigned to me in cloud12, and the servers are 

e20-{h25-7425,h27-7425,h29-7525,h31-7525}.example.com

@QuantumPosix does this look ok?