### PR TITLE
fix: aiohttp verify_ssl

### DIFF
--- a/src/badfish/badfish.py
+++ b/src/badfish/badfish.py
@@ -109,17 +109,10 @@ class Badfish:
             async with self.semaphore:
                 async with aiohttp.ClientSession() as session:
                     async with session.get(
-<<<<<<< Updated upstream
-                            uri,
-                            auth=aiohttp.BasicAuth(self.username, self.password),
-                            verify_ssl=False,
-                            timeout=60,
-=======
                         uri,
                         auth=aiohttp.BasicAuth(self.username, self.password),
                         ssl=False,
                         timeout=60,
->>>>>>> Stashed changes
                     ) as _response:
                         await _response.read()
         except (Exception, TimeoutError) as ex:
@@ -136,19 +129,11 @@ class Badfish:
             async with self.semaphore:
                 async with aiohttp.ClientSession() as session:
                     async with session.post(
-<<<<<<< Updated upstream
-                            uri,
-                            data=json.dumps(payload),
-                            headers=headers,
-                            auth=aiohttp.BasicAuth(self.username, self.password),
-                            verify_ssl=False,
-=======
                         uri,
                         data=json.dumps(payload),
                         headers=headers,
                         auth=aiohttp.BasicAuth(self.username, self.password),
                         ssl=False,
->>>>>>> Stashed changes
                     ) as _response:
                         if _response.status != 204:
                             await _response.read()
@@ -164,19 +149,11 @@ class Badfish:
             async with self.semaphore:
                 async with aiohttp.ClientSession() as session:
                     async with session.patch(
-<<<<<<< Updated upstream
-                            uri,
-                            data=json.dumps(payload),
-                            headers=headers,
-                            auth=aiohttp.BasicAuth(self.username, self.password),
-                            verify_ssl=False,
-=======
                         uri,
                         data=json.dumps(payload),
                         headers=headers,
                         auth=aiohttp.BasicAuth(self.username, self.password),
                         ssl=False,
->>>>>>> Stashed changes
                     ) as _response:
                         await _response.read()
         except Exception as ex:


### PR DESCRIPTION
aiohttp library changed the argument name for `verify_ssl` to just `ssl`

Closes: https://github.com/redhat-performance/badfish/issues/190