### PR TITLE
fix: async_lru not working with python3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.9-alpine
 
 RUN apk add git && apk update
 

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.9-alpine
 
 RUN apk add git && apk update
 


### PR DESCRIPTION
limiting python alpine image to python 3.9