### PR TITLE
docs: Added README instructions for RPM install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@
       * [Features](#features)
       * [Requirements](#requirements)
       * [Setup](#setup)
+         * [Badfish RPM package](#badfish-rpm-package)
          * [Badfish Standalone CLI](#badfish-standalone-cli)
          * [Badfish Standalone Script](#badfish-standalone-script)
          * [Badfish Standalone within a virtualenv](#badfish-standalone-within-a-virtualenv)
       * [Usage](#usage)
-      * [Usage via Podman](#usage-via-podman)
+        * [As Python Library](#as-python-library)
+        * [Via Podman](#via-podman)
       * [Common Operations](#common-operations)
          * [Enforcing an OpenStack Director-style interface order](#enforcing-an-openstack-director-style-interface-order)
          * [Enforcing a Foreman-style interface order](#enforcing-a-foreman-style-interface-order)
@@ -93,8 +95,20 @@ We're mostly concentrated on programmatically enforcing interface/device boot or
 * python3-devel >= ```3.6``` (If using standalone below).
 
 ## Setup
-### Badfish Standalone CLI
+### Badfish RPM package
+```bash
+dnf copr enable quadsdev/python3-badfish  -y
+dnf install python3-badfish -y
 ```
+Active releases:
+- Centos-stream 8
+- Epel for CentOS 7
+- Epel for CentOS 8
+- Fedora 33
+- Fedora 34
+- Fedora 35
+### Badfish Standalone CLI
+```bash
 git clone https://github.com/redhat-performance/badfish && cd badfish
 python setup.py build
 python setup.py install --prefix ~/.local
@@ -106,22 +120,22 @@ NOTE:
 * This is **ideal** for a non-root user, otherwise you'll get badfish in `/root/.local/bin/badfish` for example.
 * If you have problems running as root you will need to add whatever you set in `--prefix=` to your `$PATH` by adding something like the following to the end of your `~/.bashrc` file.
 
-```
+```bash
 if [ -d "$HOME/.local/bin" ] ; then
   PATH="$PATH:$HOME/.local/bin"
 fi
 ```
 
 ### Badfish Standalone Script
-```
+```bash
 git clone https://github.com/redhat-performance/badfish && cd badfish
 pip install -r requirements.txt
 ```
 NOTE:
-* This will allow the badfish script execution via ```./src/badfish/badfish.py```
+* This will allow the badfish script execution via `./src/badfish/badfish.py`
 
 ### Badfish Standalone within a virtualenv
-```
+```bash
 git clone https://github.com/redhat-performance/badfish && cd badfish
 virtualenv .badfish_venv
 source .badfish_venv/bin/activate
@@ -131,15 +145,38 @@ NOTE:
 * After using badfish, the virtual environment can be deactivated running the ```deactivate``` command
 
 ## Usage
-Badfish operates against a YAML configuration file to toggle between key:value pair sets of boot interface/device strings.  You just need to create your own interface config that matches your needs to easily swap/save interface/device boot ordering or select one-time boot devices.
+Badfish can be consumed in 2 forms after successful installation. Either via the standalone cli tool or as a python library.
+For an extensive use of the cli tool check the [Common Operations](#common-operations) section of this file.
 
-## Usage via Podman
-Badfish happily runs in a container image using podman, for this you need to first pull the Badfish image via:
+NOTE: Badfish operates against a YAML configuration file to toggle between key:value pair sets of boot interface/device strings.  You just need to create your own interface config that matches your needs to easily swap/save interface/device boot ordering or select one-time boot devices.
+
+### As Python Library
+If Badfish has been properly installed in the system (RPM package install, setuptools), then the library should be available under your python path therefore it can be imported as a python library to your python project.
+```python
+from badfish.badfish import badfish_factory
+
+badfish = await badfish_factory(
+    _host=_oob_mgmt,
+    _username=_username,
+    _password=_password,
+)
+boot_devices = await badfish.get_boot_devices()
+success = await badfish.boot_to(boot_devices[0])
+if success:
+    print("Change boot device success")
+result = await badfish.reboot_server()
+if not result:
+    print("Failed to reboot system")
 ```
+NOTE: Badfish relies heavily on asyncio for executing multiple tasks. If you will be using badfish from outside an async function you will have to provide an async event loop and run via `run_until_complete`
+
+### Via Podman
+Badfish happily runs in a container image using podman, for this you need to first pull the Badfish image via:
+```bash
 podman pull quay.io/quads/badfish
 ```
 You can then run badfish from inside the container:
-```
+```bash
 podman run -it --rm --dns $DNS_IP quay.io/quads/badfish -H $HOST -u $USER -p $PASS --reboot-only
 ```
 NOTE:
@@ -150,15 +187,15 @@ NOTE:
 
 ### Enforcing an OpenStack Director-style interface order
 In our performance/scale R&D environments TripleO-based OpenStack deployments require a specific 10/25/40GbE NIC to be the primary boot device for PXE, followed by disk, and then followed by the rest of the interfaces.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml -t director
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml -t director
 ```
 
 ### Enforcing a Foreman-style interface order
 Foreman and Red Hat Satellite (as of 6.x based on Foreman) require managed systems to first always PXE from the interface that is Foreman-managed (DHCP/PXE).  If the system is not set to build it will simply boot to local disk.  In our setup we utilize a specific NIC for this interface based on system type.
 
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml -t foreman
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml -t foreman
 ```
 
 ### Enforcing a Custom interface order
@@ -191,57 +228,57 @@ ocp5beta_f21_h23_fc640_interfaces: NIC.Slot.2-4,NIC.Slot.2-1,NIC.Slot.2-2,NIC.Sl
 
 Now you can run Badfish against the custom interface order type you have defined, refer to the [custom overrides](#host-type-overrides) on further usage examples.
 
-```
+```bash
 src/badfish/badfish.py --host-list /tmp/hosts -u root -p password -i config/idrac_interfaces.yml -t ocp5beta
 ```
 
 
 ### Forcing a one time boot to a specific device
 To force systems to perform a one-time boot to a specific device you can use the ```--boot-to``` option and pass as an argument the device you want the one-time boot to be set to. This will change the one time boot BIOS attributes OneTimeBootMode and OneTimeBootSeqDev and on the next reboot it will attempt to PXE boot or boot from that interface string.  You can obtain the device list via the `--check-boot` directive below.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --boot-to NIC.Integrated.1-3-1
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --boot-to NIC.Integrated.1-3-1
 ```
 
 ### Forcing a one time boot to a specific mac address
 To force systems to perform a one-time boot to a specific mac address you can use the ```--boot-to-mac``` option and pass as an argument the device mac address for a specific NIC that you want the one-time boot to be set to. This will change the one time boot BIOS attributes OneTimeBootMode and OneTimeBootSeqDev and on the next reboot it will attempt to PXE boot or boot from that interface.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --boot-to-mac A9:BB:4B:50:CA:54
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --boot-to-mac A9:BB:4B:50:CA:54
 ```
 
 ### Forcing a one time boot to a specific type
 To force systems to perform a one-time boot to a specific type you can use the ```--boot-to-type``` option and pass as an argument the device type, as defined on the iDRAC interfaces yaml, that you want the one-time boot to be set to. For this action you must also include the path to your interfaces yaml. This will change the one time boot BIOS attributes OneTimeBootMode and OneTimeBootSeqDev and on the next reboot it will attempt to PXE boot or boot from the first interface defined for that host type on the interfaces yaml file.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml --boot-to-type foreman
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml --boot-to-type foreman
 ```
 
 ### Forcing a one-time boot to PXE
 To force systems to perform a one-time boot to PXE, simply pass the ```--pxe``` flag to any of the commands above, by default it will pxe off the first available device for PXE booting.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml -t foreman --pxe
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml -t foreman --pxe
 ```
 
 ### Rebooting a system
 In certain cases you might need to only reboot the host, for this case we included the ```--reboot-only``` flag which will force a GracefulRestart on the target host. Note that this option is not to be used with any other option.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --reboot-only
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --reboot-only
 ```
 
 ### Power cycling a system
 For a hard reset you can use ```--power-cycle``` flag which will run a ForceOff instruction on the target host. Note that this option is not to be used with any other option.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --power-cycle
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --power-cycle
 ```
 
 ### Power State Control
 You can also turn a server on or off by using options `--power-on` and `--power-off` respectively.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --power-on
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --power-on
 ```
 
 ### Check Power State
 For checking the current power state of a server you can run badfish with the `--power-state` option.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --power-state
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --power-state
 ```
 Partial Output:
 ```
@@ -250,106 +287,106 @@ Partial Output:
 
 ### Resetting iDRAC
 For the replacement of `racadm racreset`, the optional argument `--racreset` was added. When this argument is passed to ```badfish```, a graceful restart is triggered on the iDRAC itself.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --racreset
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --racreset
 ```
 
 ### BIOS factory reset
 You can restore BIOS default settings by calling Badfish with the option `--factory-reset`.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --factory-reset
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --factory-reset
 ```
 NOTE:
 * WARNING: Use this carefully, vendor defaults differ and may be disruptive. Do not use this in the Scale Lab or ALIAS.
 
 ### Check current boot order
 To check the current boot order of a specific host you can use the ```--check-boot``` option which will return an ordered list of boot devices. Additionally you can pass the ```-i``` option which will in turn print on screen what type of host does the current boot order match as those defined on the iDRAC interfaces yaml.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml --check-boot
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml --check-boot
 ```
 
 ### Toggle boot device
 If you would like to enable or disable a boot device you can use ```--toggle-boot-device``` argument which takes the device name as input and will toggle the `Enabled` state from True to False and vice versa.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --toggle-boot-device NIC.Integrated.1-3-1```
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --toggle-boot-device NIC.Integrated.1-3-1```
 ```
 
 ### Variable number of retries
 At certain points during the execution of ```badfish``` the program might come across a non responsive resources and will automatically retry to establish connection. We have included a default value of 15 retries after failed attempts but this can be customized via the ```--retries``` optional argument which takes as input an integer with the number of desired retries.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml -t foreman --retries 20
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml -t foreman --retries 20
 ```
 
 ### Firmware inventory
 If you would like to get a detailed list of all the devices supported by iDRAC you can run ```badfish``` with the ```--firware-inventory``` option which will return a list of devices with additional device info.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --firmware-inventory
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --firmware-inventory
 ```
 
 ### Clear Job Queue
 If you would like to clear all the jobs that are queued on the remote iDRAC you can run ```badfish``` with the ```--clear-jobs``` option which query for all active jobs in the iDRAC queue and will post a request to clear the queue.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --clear-jobs
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --clear-jobs
 ```
 
 You can also force the clearing of Dell iDRAC job queues by passing the `--force` option.
 
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --clear-jobs --force
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --clear-jobs --force
 ```
 
 ### List Job Queue
 If you would like to list all active jobs that are queued on the remote iDRAC you can run ```badfish``` with the ```--ls-jobs``` option which query for all active jobs in the iDRAC queue and will return a list with all active items.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --ls-jobs
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --ls-jobs
 ```
 
 ### Check Job Status
 If you would like to the status of an existing LifeCycle controller job you can run ```badfish``` with the ```--check-job``` option and passing the job id which can be obtained via ```--ls-jobs```. This will return a detail of the specific job with status and percentage of completion.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --check-job JID_340568202796
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --check-job JID_340568202796
 ```
 
 ### Set Bios Password
 If you would like to set the bios password you can run ```badfish``` with the ```--set-bios-password``` option and passing the new password with ```--new-password```. If a password is already set you must pass this with ```--old-password``` otherwise optional.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --set-bios-password --new-password new_pass --old-password old_pass
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --set-bios-password --new-password new_pass --old-password old_pass
 ```
 
 ### Remove Bios Password
 If you would like to remove the bios password you can run ```badfish``` with the ```--remove-bios-password``` option and passing the existing password with ```--old-password```.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --remove-bios-password --old-password old_pass
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --remove-bios-password --old-password old_pass
 ```
 
 ### List Network Interfaces
 For getting a list of network interfaces with individual metadata for each you can run ```badfish``` with the ```--ls-interfaces``` option.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --ls-interfaces
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --ls-interfaces
 ```
 
 ### List Memory
 For getting a detailed list of memory devices you can run ```badfish``` with the ```--ls-memory``` option.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --ls-memory
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --ls-memory
 ```
 
 ### List Processors
 For getting a detailed list of processors you can run ```badfish``` with the ```--ls-processors``` option.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --ls-processors
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --ls-processors
 ```
 
 ### Check Virtual Media
 If you would like to check for any active virtual media you can run ```badfish``` with the ```--check-virtual-media``` option which query for all active virtual devices.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --check-virtual-media
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --check-virtual-media
 ```
 
 ### Unmount Virtual Media
 If you would like to unmount all active virtual media you can run ```badfish``` with the ```--unmount-virtual-media``` option which post a request for unmounting all active virtual devices.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --unmount-virtual-media
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --unmount-virtual-media
 ```
 NOTE:
 * This functionality is only available for SuperMicro devices.
@@ -357,7 +394,7 @@ NOTE:
 ### Get SRIOV mode
 For checking if the global SRIOV mode is enabled you can use ```--get-sriov```
 ```bash
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --get-sriov
+badfish -H mgmt-your-server.example.com -u root -p yourpass --get-sriov
 ```
 NOTE:
   * This is only supported on DELL devices.
@@ -366,11 +403,11 @@ NOTE:
 For changing the mode of the SRIOV glabal BIOS attribute, we have included 2 new arguments.
 In case the setting is in disabled mode, you can enable it by passing ```--enable-sriov```
 ```bash
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --enable-sriov
+badfish -H mgmt-your-server.example.com -u root -p yourpass --enable-sriov
 ```
 On the contrary, if you would like to disable the SRIOV mode, you can now pass ```--disable-sriov```
 ```bash
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --disable-sriov
+badfish -H mgmt-your-server.example.com -u root -p yourpass --disable-sriov
 ```
 NOTE:
   * This is only supported on DELL devices.
@@ -378,19 +415,19 @@ NOTE:
 ### Get BIOS attributes
 To get a list of all BIOS attributes we can potentially modify (some might be set as read-only), you can run badfish with ```--get-bios-attribute``` alone and this will return a list off all BIOS attributes with their current value set.
 ```bash
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --get-bios-attribute
+badfish -H mgmt-your-server.example.com -u root -p yourpass --get-bios-attribute
 ```
 
 ### Get specific BIOS attribute
 In case you would like to get a more detailed view on the parameters for a BIOS attribute you can run ```--get-bios-attribute``` including the specific name of the attribute via ```--attribute```.
 ```bash
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --get-bios-attribute --attribute ProcC1E
+badfish -H mgmt-your-server.example.com -u root -p yourpass --get-bios-attribute --attribute ProcC1E
 ```
 
 ### Set BIOS attribute
 To change the value of a bios attribute you can use ```--set-bios-attribute``` passing both ```--attribute``` and ```--value```.
 ```bash
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --set-bios-attribute --attribute ProcC1E --value Enabled
+badfish -H mgmt-your-server.example.com -u root -p yourpass --set-bios-attribute --attribute ProcC1E --value Enabled
 ```
 NOTE:
 * You can get the list of allowed values you can pass for that attribute by looking at the attribute details via ```--get-bios-attribute``` for that specific one.
@@ -398,25 +435,25 @@ NOTE:
 ### Get server screenshot
 If you would like to get a screenshot with the current state of the server you can now run badfish with ```--screenshot``` which will capture this and store it in the current directory in png format.
 ```bash
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass --screenshot
+badfish -H mgmt-your-server.example.com -u root -p yourpass --screenshot
 ```
 
 ### Bulk actions via text file with list of hosts
 In the case you would like to execute a common badfish action on a list of hosts, you can pass the optional argument ```--host-list``` in place of ```-H``` with the path to a text file with the hosts you would like to action upon and any addtional arguments defining a common action for all these hosts.
-```
-./src/badfish/badfish.py --host-list /tmp/bad-hosts -u root -p yourpass --clear-jobs
+```bash
+badfish --host-list /tmp/bad-hosts -u root -p yourpass --clear-jobs
 ```
 
 ### Verbose output
 If you would like to see a more detailed output on console you can use the ```--verbose``` option and get a additional debug logs. Note: this is the default log level for the ```--log``` argument.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml -t foreman --verbose
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml -t foreman --verbose
 ```
 
 ### Log to file
 If you would like to log the output of ```badfish``` you can use the ```--log``` option and pass the path to where you want ```badfish``` to log it's output to.
-```
-./src/badfish/badfish.py -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml -t foreman --log /tmp/bad.log
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass -i config/idrac_interfaces.yml -t foreman --log /tmp/bad.log
 ```
 
 ## iDRAC and Data Format

--- a/rpm/.gitignore
+++ b/rpm/.gitignore
@@ -2,4 +2,5 @@
 *.tar.gz
 *.src.rpm
 noarch/
+usr/
 python3-badfish.spec/

--- a/rpm/python3-badfish.spec.tpl
+++ b/rpm/python3-badfish.spec.tpl
@@ -1,19 +1,20 @@
-%global sum Badfish is a Redfish-based API tool for managing bare-metal systems via the Redfish API
-%global desc \
-Badfish is a vendor-agnostic, redfish-based API tool used to consolidate \
+%global project badfish
+%global org     redhat-performance
+%global sum     Badfish is a Redfish-based API tool for managing bare-metal systems via the Redfish API
+%global desc    Badfish is a vendor-agnostic, redfish-based API tool used to consolidate \
 management of IPMI and out-of-band interfaces for common server hardware \
 vendors.  Badfish is also a popular song from Sublime, this may be a \
 coincidence – are you a badfish too?
 
 
-Name:           python3-badfish
+Name:           python3-%{project}
 Version:        @VERSION@
 Release:        @RELEASE@%{?dist}
 Summary:        %{sum}
 
 License:        GPLv3
-URL:            https://github.com/redhat-performance/badfish
-Source0:        %{url}/archive/v%{version}/python3-badfish-%{version}.tar.gz
+URL:            https://github.com/%{org}/%{project}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python3-setuptools
@@ -35,7 +36,7 @@ BuildRequires:  python3-devel
 %doc README.md
 %license LICENSE
 %{python3_sitelib}/*
-%{_bindir}/badfish
+%{_bindir}/%{project}
 
 %changelog
 * @DATE@ Gonzalo Rafuls <gonza@redhat.com> - @VERSION@-@RELEASE@

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -4,7 +4,7 @@
 ##
 
 requests==2.20.1
-pytest==4.6
+pytest==6.2.5
 requests-mock==1.5.2
 asynctest==0.13.0
 pyyaml>=3.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}, flake8
+envlist = py{36,37,38,39,310}, flake8
 
 [testenv]
 deps = -rtests/test-requirements.txt


### PR DESCRIPTION
Added instructions for RPM install plus usage as python library.
Slight refactor of rpm.spec.tpl.
Bumped version of pytest plus added python 3.10 environment to tox
testing.