### PR TITLE
feat: split out dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ WORKDIR badfish
 
 RUN apk add build-base
 RUN pip install --no-cache-dir -r requirements.txt
-RUN python setup.py build
-RUN python setup.py install
+RUN sed -i 's/src.badfish.helpers/.helpers/' src/badfish/badfish.py
+RUN python -m build
+RUN python -m pip install dist/badfish-1.0.2.tar.gz
 
 ENTRYPOINT ["badfish"]
 CMD ["-v"]

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -2,14 +2,12 @@ FROM quay.io/quads/python39:latest
 
 RUN apk add git && apk update
 
-RUN git clone https://github.com/redhat-performance/badfish
+COPY . /badfish
 
 WORKDIR badfish
 
-RUN git checkout development
-
 RUN apk add build-base
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 RUN sed -i 's/src.badfish.helpers/.helpers/' src/badfish/badfish.py
 RUN python -m build
 RUN python -m pip install dist/badfish-1.0.2.tar.gz

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
          * [List Network Interfaces](#list-network-interfaces)
          * [List Memory](#list-memory)
          * [List Processors](#list-processors)
+         * [List Serial Number or Service Tag](#list-serial-number-or-service-tag)
          * [Check Virtual Media](#check-virtual-media)
          * [Unmount Virtual Media](#unmount-virtual-media)
          * [Get SRIOV mode](#get-sriov-mode)
@@ -379,6 +380,12 @@ badfish -H mgmt-your-server.example.com -u root -p yourpass --ls-memory
 For getting a detailed list of processors you can run ```badfish``` with the ```--ls-processors``` option.
 ```bash
 badfish -H mgmt-your-server.example.com -u root -p yourpass --ls-processors
+```
+
+### List Serial Number or Service Tag
+For getting the system's serial number or on Dell servers the service tag (equivalent to `racadm getsvctag`) you can run ```badfish``` with the ```--ls-serial``` option.
+```bash
+badfish -H mgmt-your-server.example.com -u root -p yourpass --ls-serial
 ```
 
 ### Check Virtual Media

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyyaml>=3.10
 aiohttp>=3.7.4
 setuptools>=39.0
 pillow>=5.1.0
+build>=0.7.0


### PR DESCRIPTION
* Split out dockerfiles per environment
* Force a revision to the main Dockerfile as we were troubleshooting why quay.io doesn't seem to want to build us containers with new underlying code.