### PR TITLE
feat: make tox/lint run on PR's too.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,12 @@
 name: Lint
 
 on:
-  pull_request_target:
-    types: [ opened, edited ]
-    branches: [ master ]
+  pull_request:
+    types: [opened, edited]
+    branches: [development, master]
+
   push:
-    branches: [ master ]
+    branches: [development, master]
 
 permissions:
     checks: write

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,8 +1,13 @@
 name: Tox
 
 on:
+
+  pull_request:
+    types: [opened, edited]
+    branches: [development, master]
+
   push:
-    branches: [master, development]
+    branches: [development, master]
 
 jobs:
   build:


### PR DESCRIPTION
* Run GHA CI for PR's too
* Use `pull_request` instead of `pull_request_target` as tox and lint shouldn't need access to repo secrets.
    
reference:  https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
