### PR TITLE
fix: bump README and update Codecov version, trigger Fedora 38 RPM build

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Badfish is a Redfish-based API tool for managing bare-metal systems via the [Red
 You can read more [about badfish](https://quads.dev/about-badfish/) at the [QUADS](https://quads.dev/) website.
 
 ## Scope
-Right now Badfish is focused on managing Dell, SuperMicro and HPE systems, but can potentially work with any system that supports the Redfish API.  Functionality may vary depending on the vendor Redfish implementation.
+Right now Badfish is focused on managing Dell, SuperMicro and HPE systems, but can potentially work with any system that supports the Redfish API.  Functionality may vary depending on the vendor Redfish implementation with Dell systems having the most functionality.
 
 We're mostly concentrated on programmatically enforcing interface/device boot order to accommodate [TripleO](https://docs.openstack.org/tripleo-docs/latest/) based [OpenStack](https://www.openstack.org/) and [OpenShift](https://www.openshift.com/) deployments while simultaneously allowing easy management and provisioning of those same systems via [The Foreman](https://theforeman.org/).  Badfish can be useful as a general standalone, unified vendor IPMI/OOB tool however as support for more vendors is added.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ We're mostly concentrated on programmatically enforcing interface/device boot or
 * Display current power consumption in watts
 * Reboot host
 * Reset iDRAC
-* Clear iDRAC job queue
+* View, check and clear iDRAC jobs
 * Revert to factory settings
 * Check/set SRIOV
 * Take a remote screenshot of server KVM console activity (Dell only).

--- a/src/badfish/main.py
+++ b/src/badfish/main.py
@@ -1732,7 +1732,6 @@ class Badfish:
         return values
 
     async def get_processor_details(self):
-
         _url = "%s%s/Processors" % (self.host_uri, self.system_resource)
         _response = await self.get_request(_url)
 
@@ -1810,7 +1809,6 @@ class Badfish:
         return values
 
     async def get_memory_details(self):
-
         _url = "%s%s/Memory" % (self.host_uri, self.system_resource)
         _response = await self.get_request(_url)
 

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -5,7 +5,7 @@
 
 pytest==6.2.5
 pytest-cov==3.0.0
-codecov==2.1.12
+codecov==2.1.13
 asynctest==0.13.0
 pyyaml>=3.10
 aiohttp>=3.7.4


### PR DESCRIPTION
fix: bump README to trigger Fedora38 RPM build and update codecov version (CI gets mad if not `2.1.13` now)