### PR TITLE
GHA with ubuntu-latest wants at least Python 3.9 now

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install Python dependencies
         run: pip install black flake8

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11",]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11",]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
* GHA's ubuntu-latest image now wants a minimum of Python 3.9 for CI.