### PR TITLE
fix: removed problematic call from boot_to()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ venv.bak/
 
 # SCP Exports folder (Testing purpose)
 tests/exports/
+exports/

--- a/tests/config.py
+++ b/tests/config.py
@@ -118,8 +118,6 @@ RESPONSE_BOOT_TO_SERVICE_BAD_REQUEST = (
     "- INFO     - iDRAC will now reset and be back online within a few minutes.\n"
     "- INFO     - Polling for host state: On\n"
     "- INFO     - Command passed to set BIOS attribute pending values.\n"
-    "- ERROR    - POST command failed to create BIOS config job, status code is 400.\n"
-    "- ERROR    - {'JobID': 'JID_498218641680'}\n"
 )
 RESPONSE_BOOT_TO_SERVICE_ERR_HANDLER = (
     f"- WARNING  - Job queue already cleared for iDRAC {MOCK_HOST}, DELETE command will not execute.\n"


### PR DESCRIPTION
closes: #354

The problem/bug from #354 was found to be present only on Dell systems. It appeared when forcing a one time boot to a specific device and virtual media. 
This functionality of commands using this approach was still right/valid (after rebooting the server it booted to the specified device), only the CLI output/log was displaying errors.
The cause of this was found to be a call of `create_bios_config_job()` right after `send_one_time_boot()` in the `boot_to()` function. The errors were happening because iDRAC already created the needed config job since the patch request was called with specified apply time to on reset (`payload_patch = {"@Redfish.SettingsApplyTime": {"ApplyTime": "OnReset"}}`).
Thus that call was removed since it wasn't needed and the functionality was tested to still be valid.

Also a problem with a getting virtual media config paths was found on Supermicro systems and fixed. 
Fixed along with this was a `TypeError` problem while getting BIOS attributes.