### PR TITLE
:bug: Fix for custom overrides

### DIFF
--- a/config/idrac_interfaces.yml
+++ b/config/idrac_interfaces.yml
@@ -65,6 +65,8 @@ director_e27_r750_interfaces: NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.S
 director_e28_r750_interfaces: NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,NIC.Embedded.1-1-1,HardDisk.List.1-1
 foreman_e27_r750_interfaces: NIC.Embedded.1-1-1,NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,HardDisk.List.1-1
 foreman_e28_r750_interfaces: NIC.Embedded.1-1-1,NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,HardDisk.List.1-1
+uefi_e27_r750_interfaces: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Embedded.1-1-1
+uefi_e28_r750_interfaces: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Embedded.1-1-1
 
 ## Custom F04 specific overrides (examples)
 ## h34 (should resemble other r640 hosts)

--- a/src/badfish/main.py
+++ b/src/badfish/main.py
@@ -202,9 +202,12 @@ class Badfish:
 
         host_name_split = self.host.split(".")[0].split("-")
         host_model = host_name_split[-1]
-        host_blade = host_name_split[-2]
-        uloc = host_name_split[-3]
-        rack = host_name_split[-4]
+        rack = host_name_split[1]
+        uloc = host_name_split[2]
+
+        host_blade = "000"
+        if len(host_name_split) > 4:
+            host_blade = host_name_split[3]
 
         prefix = [host_type, rack, uloc]
 

--- a/tests/test_custom_interfaces.py
+++ b/tests/test_custom_interfaces.py
@@ -1,0 +1,44 @@
+from unittest import IsolatedAsyncioTestCase
+from src.badfish.main import Badfish
+from tests.config import INTERFACES_PATH
+
+E26_EXPECTED_INTERFACES = {
+    "director": "NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1",
+    "foreman": "NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1-1",
+    "uefi": "NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1",
+}
+
+E27_EXPECTED_INTERFACES = {
+    "director": "NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,NIC.Embedded.1-1-1,HardDisk.List.1-1",
+    "foreman": "NIC.Embedded.1-1-1,NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,HardDisk.List.1-1",
+    "uefi": "NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Embedded.1-1-1",
+}
+
+FC640_B01_INTERFACES = {
+    "uefi": "NIC.ChassisSlot.8-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1",
+}
+
+FC640_B02_INTERFACES = {
+    "uefi": "NIC.ChassisSlot.4-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1",
+}
+
+
+class TestGetInterfaceByType(IsolatedAsyncioTestCase):
+    async def test_get_interface_by_type(self):
+        for host, expected in [
+            ("mgmt-e26-h01-r750", E26_EXPECTED_INTERFACES),
+            ("mgmt-e27-h01-r750", E27_EXPECTED_INTERFACES),
+            ("mgmt-e26-h01-000-r750", E26_EXPECTED_INTERFACES),
+            ("mgmt-e27-h01-000-r750", E27_EXPECTED_INTERFACES),
+            ("mgmt-e99-h01-b01-fc640", FC640_B01_INTERFACES),
+            ("mgmt-e99-h01-b02-fc640", FC640_B02_INTERFACES),
+        ]:
+            for host_type in expected:
+                expected_interfaces = expected[host_type].split(",")
+                with self.subTest(host=host, host_type=host_type):
+                    badfish = Badfish(_host=host, _username="", _password="", _logger="", _retries="",)
+                    interfaces = await badfish.get_interfaces_by_type(host_type, _interfaces_path=INTERFACES_PATH)
+                    assert interfaces == expected_interfaces, (
+                        f"{host_type} interfaces for host: {host} : "
+                        f"{interfaces} does not match expected: {expected_interfaces}"
+                    )


### PR DESCRIPTION
When utilizing badfish in alias on e27/e28 rack for Dell R750 Found host was not parsed properly for custom interfaces.

I'm sure there is a more comprehensive fix, thoughts?