### PR TITLE
Sanitize variable which can be controlled by user input

### DIFF
--- a/.github/workflows/issuetracker-webhook.yml
+++ b/.github/workflows/issuetracker-webhook.yml
@@ -20,7 +20,7 @@ jobs:
           echo "Using issue_title: $issue_title"
       - name: Google Chat Notification
         run: |
-            export issue_title=$(echo "${{ github.event.issue.title }}" | sed -e "s/'//g" -e 's/"//g')
+            export issue_title=$(echo "$ISSUE_TITLE" | sed -e "s/'//g" -e 's/"//g')
             curl --location --request POST '${{ secrets.WEBHOOK }}' \
             --header 'Content-Type: application/json; charset=UTF-8' \
             --data "{'text': '[${{ github.event.issue.number }}] ${{ github.event.issue.html_url }} $issue_title (${{ github.event.issue.user.login }})'}"


### PR DESCRIPTION
You are using a variable which can be controlled by user input, and it may result in command execution on your runners, and secrets extraction by malicious actors.

Since the ${{ github.event.issue.title }} value can be controlled by the user who creates the issue, a malicious actor can inject system command that will run on the GitHub runner while the workflow is in progress and fetch sensitive data which stored there such as GitHub token with write permissions.

