### PR TITLE
feat+test: nic attribute modification

### DIFF
--- a/src/badfish/main.py
+++ b/src/badfish/main.py
@@ -2,6 +2,7 @@
 import asyncio
 import base64
 import functools
+import pprint
 
 import aiohttp
 import json
@@ -2192,6 +2193,211 @@ class Badfish:
                 continue
         return True
 
+    async def get_nic_fqdds(self):
+        uri = "%s%s/NetworkAdapters" % (self.host_uri, self.system_resource)
+        resp = await self.get_request(uri)
+        if resp.status == 404 or self.vendor == "Supermicro":
+            self.logger.error("Operation not supported by vendor.")
+            return False
+
+        try:
+            raw = await resp.text("utf-8", "ignore")
+            data = json.loads(raw.strip())
+            nic_list = [[nic[1].split("/")[-1] for nic in member.items()][0] for member in data.get("Members")]
+            self.logger.debug(f"Detected NIC FQDDs for existing network adapters.")
+            for nic in nic_list:
+                uri = "%s%s/NetworkAdapters/%s/NetworkDeviceFunctions" % (self.host_uri, self.system_resource, nic)
+                resp = await self.get_request(uri)
+                raw = await resp.text("utf-8", "ignore")
+                data = json.loads(raw.strip())
+                nic_fqqds = [[fqdd[1].split("/")[-1] for fqdd in member.items()][0] for member in data.get("Members")]
+                self.logger.info(f"{nic}:")
+                for i, fqdd in enumerate(nic_fqqds, start=1):
+                    self.logger.info(f"    {i}: {fqdd}")
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError) as e:
+            self.logger.error("Was unable to get NIC FQDDs, invalid server response.")
+            return False
+        return True
+
+    async def get_nic_attribute(self, fqdd, log=True):
+        try:
+            uri = "%s/Chassis/%s/NetworkAdapters/%s/NetworkDeviceFunctions/%s/Oem/Dell/DellNetworkAttributes/%s" % (
+                self.root_uri,
+                self.system_resource.split("/")[-1],
+                fqdd.split("-")[0],
+                fqdd,
+                fqdd
+            )
+        except (IndexError, ValueError):
+            self.logger.error("Invalid FQDD supplied.")
+            return False
+        resp = await self.get_request(uri)
+        if resp.status == 404 or self.vendor == "Supermicro":
+            self.logger.error("Operation not supported by vendor.")
+            return False
+
+        try:
+            raw = await resp.text("utf-8", "ignore")
+            data = json.loads(raw.strip())
+            attributes_list = [(key, value) for key, value in data.get("Attributes").items()]
+            if not log:
+                return attributes_list
+            self.logger.debug(f"All NIC attributes of {fqdd}.")
+            self.logger.info(f"{fqdd}")
+            for key, value in attributes_list:
+                self.logger.info(f"    {key}: {value}")
+        except (AttributeError, KeyError, TypeError,ValueError):
+            self.logger.error("Was unable to get NIC attribute(s) info, invalid server response.")
+            return False
+        return True
+
+    async def get_idrac_fw_version(self):
+        idrac_fw_version = 0
+        try:
+            uri = "%s%s/" % (self.host_uri, self.manager_resource)
+            resp = await self.get_request(uri)
+            if resp.status == 404 or self.vendor == "Supermicro":
+                self.logger.error("Operation not supported by vendor.")
+                return 0
+            raw = await resp.text("utf-8", "ignore")
+            data = json.loads(raw.strip())
+            idrac_fw_version = int(data["FirmwareVersion"].replace(".", ""))
+        except (AttributeError, ValueError):
+            self.logger.error("Was unable to get iDRAC Firmware Version.")
+            return 0
+        return idrac_fw_version
+
+    async def get_nic_attribute_registry(self, fqdd=None):
+        registry = []
+        idrac_fw_version = await self.get_idrac_fw_version()
+        if not idrac_fw_version or idrac_fw_version < 5100000:
+            self.logger.error("Unsupported iDRAC version.")
+            return []
+        try:
+            uri = "%s/Registries/NetworkAttributesRegistry_%s/NetworkAttributesRegistry_%s.json" % (self.root_uri, fqdd, fqdd)
+            resp = await self.get_request(uri)
+            if resp.status == 404:
+                self.logger.error("Was unable to get network attribute registry.")
+                return []
+            raw = await resp.text("utf-8", "ignore")
+            data = json.loads(raw.strip())
+            registry = [attr for attr in data.get("RegistryEntries").get("Attributes")]
+        except (AttributeError, KeyError, TypeError, ValueError):
+            self.logger.error("Was unable to get network attribute registry.")
+            return []
+        return registry
+
+    async def get_nic_attribute_info(self, fqdd, attribute, log=True):
+        if self.vendor == "Supermicro":
+            self.logger.error("Operation not supported by vendor.")
+            return False
+        registry = await self.get_nic_attribute_registry(fqdd)
+        if not registry:
+            self.logger.error("Was unable to get network attribute info.")
+            return False
+        try:
+            registry = [attr_dict for attr_dict in registry if attr_dict.get("AttributeName") == attribute][0]
+            current_value = await self.get_nic_attribute(fqdd, False)
+            current_value = [tup[1] for tup in current_value if tup[0] == attribute][0]
+            registry.update({"CurrentValue": current_value})
+            if not log:
+                return registry
+            for key, value in registry.items():
+                self.logger.info(f"{key}: {value}")
+        except (AttributeError, IndexError, KeyError, TypeError):
+            self.logger.error("Was unable to get network attribute info.")
+            return False
+        return True
+
+    async def set_nic_attribute(self, fqdd, attribute, value):
+        # TODO: Fix after iDRAC version update.
+        self.logger.error("Operation not yet supported due to iDRAC version problems.")
+        return False
+
+        if self.vendor == "Supermicro":
+            self.logger.error("Operation not supported by vendor.")
+            return False
+
+        attr_info = await self.get_nic_attribute_info(fqdd, attribute, False)
+        if not attr_info:
+            self.logger.error("Was unable to set a network attribute. Attribute most likely doesn't exist.")
+            return False
+
+        try:
+            type = attr_info.get("Type")
+            current_value = attr_info.get("CurrentValue")
+            if value == current_value:
+                self.logger.warning("This attribute already is set to this value. Skipping.")
+                return True
+            if type == "Enumeration":
+                allowed_values = [value_spec.get("ValueName") for value_spec in attr_info.get("Value")]
+                if not value in allowed_values:
+                    self.logger.error("Value not allowed for this attribute.")
+                    self.logger.error("Was unable to set a network attribute.")
+                    return False
+            if type == "String":
+                max, min = int(attr_info.get("MaxLength")), int(attr_info.get("MinLength"))
+                if len(value) > max or len(value) < min:
+                    self.logger.error("Value not allowed for this attribute. (Incorrect string length)")
+                    self.logger.error("Was unable to set a network attribute.")
+                    return False
+            if type == "Integer":
+                max, min = int(attr_info.get("UpperBound")), int(attr_info.get("LowerBound"))
+                value = int(value)
+                if value > max or value < min:
+                    self.logger.error("Value not allowed for this attribute. (Incorrect number bounds)")
+                    self.logger.error("Was unable to set a network attribute.")
+                    return False
+        except (AttributeError, IndexError, KeyError, TypeError):
+            self.logger.error("Was unable to set a network attribute.")
+            return False
+
+        try:
+            uri = "%s/Chassis/System.Embedded.1/NetworkAdapters/%s/NetworkDeviceFunctions/%s/Oem/Dell/DellNetworkAttributes/%s/Settings" % (
+                self.root_uri,
+                fqdd.split("-")[0],
+                fqdd,
+                fqdd,
+            )
+            self.logger.info(uri)
+        except (IndexError, ValueError):
+            self.logger.error("Invalid FQDD suplied.")
+            return False
+
+        headers = {'content-type': 'application/json'}
+        payload = {
+            "@Redfish.SettingsApplyTime": {"ApplyTime": "OnReset"},
+            "Attributes": {attribute: value},
+        }
+        first_reset = False
+        try:
+            for i in range(self.retries):
+                response = await self.patch_request(uri, payload, headers)
+                status_code = response.status
+                if status_code in [200, 202]:
+                    self.logger.info("Patch command to set network attribute values and create next reboot job PASSED.")
+                else:
+                    self.logger.error("Patch command to set network attribute values and create next reboot job FAILED, error code is: %s." % status_code)
+                    if status_code == 503 and i - 1 != self.retries:
+                        self.logger.info("Retrying to send the patch command.")
+                        continue
+                    elif status_code == 400:
+                        self.logger.info("Retrying to send the patch command.")
+                        await self.clear_job_queue()
+                        if not first_reset:
+                            await self.reset_idrac()
+                            await asyncio.sleep(10)
+                            first_reset = True
+                        continue
+                    self.logger.error("Patch command to set network attribute values and create next reboot job FAILED, error code is: %s." % status_code)
+                    self.logger.error("Was unable to set a network attribute.")
+                    return False
+        except (AttributeError, ValueError):
+            self.logger.error("Was unable to set a network attribute.")
+
+        await self.reboot_server()
+
+
 
 async def execute_badfish(_host, _args, logger, format_handler=None):
     _username = _args["u"]
@@ -2248,6 +2454,10 @@ async def execute_badfish(_host, _args, logger, format_handler=None):
     scp_include_read_only = _args["scp_include_read_only"]
     export_scp = _args["export_scp"]
     import_scp = _args["import_scp"]
+    get_nic_fqdds = _args["get_nic_fqdds"]
+    get_nic_attribute = _args["get_nic_attribute"]
+    # TODO: Fix after iDRAC version update.
+    # set_nic_attribute = _args["set_nic_attribute"]
     result = True
 
     try:
@@ -2354,6 +2564,16 @@ async def execute_badfish(_host, _args, logger, format_handler=None):
             await badfish.export_scp(export_scp, scp_targets, scp_include_read_only)
         elif import_scp:
             await badfish.import_scp(import_scp, scp_targets)
+        elif get_nic_fqdds:
+            await badfish.get_nic_fqdds()
+        elif get_nic_attribute:
+            if attribute:
+                await badfish.get_nic_attribute_info(get_nic_attribute, attribute)
+            else:
+                await badfish.get_nic_attribute(get_nic_attribute)
+        # TODO: Fix after iDRAC version update.
+        # elif set_nic_attribute:
+        #     await badfish.set_nic_attribute(set_nic_attribute, attribute, value)
 
         if pxe and not host_type:
             await badfish.set_next_boot_pxe()
@@ -2631,6 +2851,22 @@ def main(argv=None):
         "imported.",
         default="",
     )
+    parser.add_argument(
+        "--get-nic-fqdds",
+        help="List FQDDs for all NICs.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--get-nic-attribute",
+        help="Get a NIC attribute values, specify a NIC FQDD.",
+        default="",
+    )
+    # TODO: Fix after iDRAC version update.
+    # parser.add_argument(
+    #     "--set-nic-attribute",
+    #     help="Set a NIC attribute value",
+    #     default="",
+    # )
 
     _args = vars(parser.parse_args(argv))
 

--- a/src/badfish/main.py
+++ b/src/badfish/main.py
@@ -2,7 +2,6 @@
 import asyncio
 import base64
 import functools
-import pprint
 
 import aiohttp
 import json
@@ -2204,7 +2203,7 @@ class Badfish:
             raw = await resp.text("utf-8", "ignore")
             data = json.loads(raw.strip())
             nic_list = [[nic[1].split("/")[-1] for nic in member.items()][0] for member in data.get("Members")]
-            self.logger.debug(f"Detected NIC FQDDs for existing network adapters.")
+            self.logger.debug("Detected NIC FQDDs for existing network adapters.")
             for nic in nic_list:
                 uri = "%s%s/NetworkAdapters/%s/NetworkDeviceFunctions" % (self.host_uri, self.system_resource, nic)
                 resp = await self.get_request(uri)
@@ -2214,7 +2213,7 @@ class Badfish:
                 self.logger.info(f"{nic}:")
                 for i, fqdd in enumerate(nic_fqqds, start=1):
                     self.logger.info(f"    {i}: {fqdd}")
-        except (AttributeError, IndexError, KeyError, TypeError, ValueError) as e:
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError):
             self.logger.error("Was unable to get NIC FQDDs, invalid server response.")
             return False
         return True
@@ -2226,7 +2225,7 @@ class Badfish:
                 self.system_resource.split("/")[-1],
                 fqdd.split("-")[0],
                 fqdd,
-                fqdd
+                fqdd,
             )
         except (IndexError, ValueError):
             self.logger.error("Invalid FQDD supplied.")
@@ -2246,7 +2245,7 @@ class Badfish:
             self.logger.info(f"{fqdd}")
             for key, value in attributes_list:
                 self.logger.info(f"    {key}: {value}")
-        except (AttributeError, KeyError, TypeError,ValueError):
+        except (AttributeError, KeyError, TypeError, ValueError):
             self.logger.error("Was unable to get NIC attribute(s) info, invalid server response.")
             return False
         return True
@@ -2274,7 +2273,11 @@ class Badfish:
             self.logger.error("Unsupported iDRAC version.")
             return []
         try:
-            uri = "%s/Registries/NetworkAttributesRegistry_%s/NetworkAttributesRegistry_%s.json" % (self.root_uri, fqdd, fqdd)
+            uri = "%s/Registries/NetworkAttributesRegistry_%s/NetworkAttributesRegistry_%s.json" % (
+                self.root_uri,
+                fqdd,
+                fqdd,
+            )
             resp = await self.get_request(uri)
             if resp.status == 404:
                 self.logger.error("Was unable to get network attribute registry.")
@@ -2331,7 +2334,7 @@ class Badfish:
                 return True
             if type == "Enumeration":
                 allowed_values = [value_spec.get("ValueName") for value_spec in attr_info.get("Value")]
-                if not value in allowed_values:
+                if value not in allowed_values:
                     self.logger.error("Value not allowed for this attribute.")
                     self.logger.error("Was unable to set a network attribute.")
                     return False
@@ -2353,18 +2356,21 @@ class Badfish:
             return False
 
         try:
-            uri = "%s/Chassis/System.Embedded.1/NetworkAdapters/%s/NetworkDeviceFunctions/%s/Oem/Dell/DellNetworkAttributes/%s/Settings" % (
-                self.root_uri,
-                fqdd.split("-")[0],
-                fqdd,
-                fqdd,
+            uri = (
+                "%s/Chassis/System.Embedded.1/NetworkAdapters/%s/NetworkDeviceFunctions/%s/Oem/Dell/DellNetworkAttributes/%s/Settings"
+                % (
+                    self.root_uri,
+                    fqdd.split("-")[0],
+                    fqdd,
+                    fqdd,
+                )
             )
             self.logger.info(uri)
         except (IndexError, ValueError):
             self.logger.error("Invalid FQDD suplied.")
             return False
 
-        headers = {'content-type': 'application/json'}
+        headers = {"content-type": "application/json"}
         payload = {
             "@Redfish.SettingsApplyTime": {"ApplyTime": "OnReset"},
             "Attributes": {attribute: value},
@@ -2377,7 +2383,10 @@ class Badfish:
                 if status_code in [200, 202]:
                     self.logger.info("Patch command to set network attribute values and create next reboot job PASSED.")
                 else:
-                    self.logger.error("Patch command to set network attribute values and create next reboot job FAILED, error code is: %s." % status_code)
+                    self.logger.error(
+                        "Patch command to set network attribute values and create next reboot job FAILED, error code is: %s."
+                        % status_code
+                    )
                     if status_code == 503 and i - 1 != self.retries:
                         self.logger.info("Retrying to send the patch command.")
                         continue
@@ -2389,14 +2398,16 @@ class Badfish:
                             await asyncio.sleep(10)
                             first_reset = True
                         continue
-                    self.logger.error("Patch command to set network attribute values and create next reboot job FAILED, error code is: %s." % status_code)
+                    self.logger.error(
+                        "Patch command to set network attribute values and create next reboot job FAILED, error code is: %s."
+                        % status_code
+                    )
                     self.logger.error("Was unable to set a network attribute.")
                     return False
         except (AttributeError, ValueError):
             self.logger.error("Was unable to set a network attribute.")
 
         await self.reboot_server()
-
 
 
 async def execute_badfish(_host, _args, logger, format_handler=None):

--- a/tests/config.py
+++ b/tests/config.py
@@ -1225,3 +1225,1072 @@ RESPONSE_IMPORT_SCP_PASS = f"""\
 - INFO     - Successfully imported and applied Server Configuration Profile., percent complete: 100
 - INFO     - Command passed, job successfully marked as completed. Going to reboot.
 """
+GET_NIC_FQQDS_ADAPTERS = """{
+    "@odata.context":"/redfish/v1/$metadata#NetworkAdapterCollection.NetworkAdapterCollection",
+    "@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters",
+    "@odata.type":"#NetworkAdapterCollection.NetworkAdapterCollection",
+    "Description":"Collection Of Network Adapter",
+    "Members":[
+        {"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Embedded.1"},
+        {"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Integrated.1"},
+        {"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Slot.3"}
+    ],
+    "Members@odata.count":3,
+    "Name":"Network Adapter Collection"
+}
+"""
+GET_NIC_FQQDS_EMBEDDED = """{
+    "@odata.context":"/redfish/v1/$metadata#NetworkDeviceFunctionCollection.NetworkDeviceFunctionCollection",
+    "@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Embedded.1/NetworkDeviceFunctions",
+    "@odata.type":"#NetworkDeviceFunctionCollection.NetworkDeviceFunctionCollection",
+    "Description":"Collection Of Network Device Function entities",
+    "Members":[
+        {"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Embedded.1/NetworkDeviceFunctions/NIC.Embedded.1-1-1"},
+        {"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Embedded.1/NetworkDeviceFunctions/NIC.Embedded.2-1-1"}
+    ],
+    "Members@odata.count":2,
+    "Name":"Network Device Function Collection"
+}
+"""
+GET_NIC_FQQDS_INTEGRATED = """{
+    "@odata.context":"/redfish/v1/$metadata#NetworkDeviceFunctionCollection.NetworkDeviceFunctionCollection",
+    "@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Integrated.1/NetworkDeviceFunctions",
+    "@odata.type":"#NetworkDeviceFunctionCollection.NetworkDeviceFunctionCollection",
+    "Description":"Collection Of Network Device Function entities",
+    "Members":[
+        {"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Integrated.1/NetworkDeviceFunctions/NIC.Integrated.1-1-1"},
+        {"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Integrated.1/NetworkDeviceFunctions/NIC.Integrated.1-2-1"}
+    ],
+    "Members@odata.count":2,
+    "Name":"Network Device Function Collection"
+}
+"""
+GET_NIC_FQQDS_SLOT = """{
+    "@odata.context":"/redfish/v1/$metadata#NetworkDeviceFunctionCollection.NetworkDeviceFunctionCollection",
+    "@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Slot.3/NetworkDeviceFunctions",
+    "@odata.type":"#NetworkDeviceFunctionCollection.NetworkDeviceFunctionCollection",
+    "Description":"Collection Of Network Device Function entities",
+    "Members":[
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Slot.3/NetworkDeviceFunctions/NIC.Slot.3-1-1"},
+        {"@odata.id": "/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Slot.3/NetworkDeviceFunctions/NIC.Slot.3-2-1"}
+    ],
+    "Members@odata.count":2,
+    "Name":"Network Device Function Collection"
+}
+"""
+RESPONSE_GET_NIC_FQQDS_OK = """\
+- INFO     - NIC.Embedded.1:
+- INFO     -     1: NIC.Embedded.1-1-1
+- INFO     -     2: NIC.Embedded.2-1-1
+- INFO     - NIC.Integrated.1:
+- INFO     -     1: NIC.Integrated.1-1-1
+- INFO     -     2: NIC.Integrated.1-2-1
+- INFO     - NIC.Slot.3:
+- INFO     -     1: NIC.Slot.3-1-1
+- INFO     -     2: NIC.Slot.3-2-1
+"""
+RESPONSE_GET_NIC_FQQDS_UNSUPPORTED = "- ERROR    - Operation not supported by vendor.\n"
+RESPONSE_GET_NIC_FQQDS_INVALID = "- ERROR    - Was unable to get NIC FQDDs, invalid server response.\n"
+GET_NIC_ATTR_LIST = """\
+{
+    "@Redfish.Settings":{
+        "@odata.context":"/redfish/v1/$metadata#Settings.Settings",
+        "@odata.type":"#Settings.v1_3_1.Settings",
+        "SettingsObject":{"@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Embedded.1/NetworkDeviceFunctions/NIC.Embedded.1-1-1/Oem/Dell/DellNetworkAttributes/NIC.Embedded.1-1-1/Settings"},
+        "SupportedApplyTimes":[
+            "Immediate",
+            "AtMaintenanceWindowStart",
+            "OnReset",
+            "InMaintenanceWindowOnReset"
+        ]
+    },
+    "@odata.context":"/redfish/v1/$metadata#DellAttributes.DellAttributes",
+    "@odata.id":"/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Embedded.1/NetworkDeviceFunctions/NIC.Embedded.1-1-1/Oem/Dell/DellNetworkAttributes/NIC.Embedded.1-1-1",
+    "@odata.type":"#DellAttributes.v1_0_0.DellAttributes",
+    "AttributeRegistry":"NetworkAttributeRegistry_NIC.Embedded.1-1-1",
+    "Attributes":{
+        "ChipMdl":"BCM5720 A0",
+        "PCIDeviceID":"165F",
+        "BusDeviceFunction":"04:00:00",
+        "MacAddr":"C8:4B:D6:83:16:00",
+        "VirtMacAddr":"C8:4B:D6:83:16:00",
+        "FCoEOffloadSupport":"Unavailable",
+        "iSCSIOffloadSupport":"Unavailable",
+        "iSCSIBootSupport":"Unavailable",
+        "PXEBootSupport":"Available",
+        "FCoEBootSupport":"Unavailable",
+        "NicPartitioningSupport":"Unavailable",
+        "FlexAddressing":"Unavailable",
+        "TXBandwidthControlMaximum":"Unavailable",
+        "TXBandwidthControlMinimum":"Unavailable",
+        "EnergyEfficientEthernet":"Available",
+        "FamilyVersion":"22.00.6",
+        "ControllerBIOSVersion":"1.39",
+        "EFIVersion":"21.6.29",
+        "BlnkLeds":0,
+        "BannerMessageTimeout":5,
+        "VLanId":1,
+        "EEEControl":"Enabled",
+        "LinkStatus":"Disconnected",
+        "BootOptionROM":"Enabled",
+        "LegacyBootProto":"NONE",
+        "BootStrapType":"AutoDetect",
+        "HideSetupPrompt":"Disabled",
+        "LnkSpeed":"AutoNeg",
+        "WakeOnLan":"Enabled",
+        "VLanMode":"Disabled",
+        "PermitTotalPortShutdown":"Disabled"
+    },
+    "Description":"DellNetworkAttributes represents the Network device attribute details.",
+    "Id":"NIC.Embedded.1-1-1",
+    "Name":"DellNetworkAttributes"
+}
+"""
+RESPONSE_GET_NIC_ATTR_LIST_OK = """\
+- INFO     - NIC.Embedded.1-1-1
+- INFO     -     ChipMdl: BCM5720 A0
+- INFO     -     PCIDeviceID: 165F
+- INFO     -     BusDeviceFunction: 04:00:00
+- INFO     -     MacAddr: C8:4B:D6:83:16:00
+- INFO     -     VirtMacAddr: C8:4B:D6:83:16:00
+- INFO     -     FCoEOffloadSupport: Unavailable
+- INFO     -     iSCSIOffloadSupport: Unavailable
+- INFO     -     iSCSIBootSupport: Unavailable
+- INFO     -     PXEBootSupport: Available
+- INFO     -     FCoEBootSupport: Unavailable
+- INFO     -     NicPartitioningSupport: Unavailable
+- INFO     -     FlexAddressing: Unavailable
+- INFO     -     TXBandwidthControlMaximum: Unavailable
+- INFO     -     TXBandwidthControlMinimum: Unavailable
+- INFO     -     EnergyEfficientEthernet: Available
+- INFO     -     FamilyVersion: 22.00.6
+- INFO     -     ControllerBIOSVersion: 1.39
+- INFO     -     EFIVersion: 21.6.29
+- INFO     -     BlnkLeds: 0
+- INFO     -     BannerMessageTimeout: 5
+- INFO     -     VLanId: 1
+- INFO     -     EEEControl: Enabled
+- INFO     -     LinkStatus: Disconnected
+- INFO     -     BootOptionROM: Enabled
+- INFO     -     LegacyBootProto: NONE
+- INFO     -     BootStrapType: AutoDetect
+- INFO     -     HideSetupPrompt: Disabled
+- INFO     -     LnkSpeed: AutoNeg
+- INFO     -     WakeOnLan: Enabled
+- INFO     -     VLanMode: Disabled
+- INFO     -     PermitTotalPortShutdown: Disabled
+"""
+RESPONSE_GET_NIC_ATTR_LIST_UNSUPPORTED = "- ERROR    - Operation not supported by vendor.\n"
+RESPONSE_GET_NIC_ATTR_LIST_INVALID = "- ERROR    - Was unable to get NIC attribute(s) info, invalid server response.\n"
+GET_FW_VERSION = """\
+{
+    "FirmwareVersion":"5.10.50.00"
+}
+"""
+GET_FW_VERSION_UNSUPPORTED = """\
+{
+    "FirmwareVersion":"4.10.50.00"
+}
+"""
+GET_NIC_ATTR_REGISTRY = """
+{
+    "@odata.context": "/redfish/v1/$metadata#AttributeRegistry.AttributeRegistry",
+    "@odata.id": "/redfish/v1/Registries/NetworkAttributesRegistry_NIC.Embedded.1-1-1/NetworkAttributesRegistry_NIC.Embedded.1-1-1.json",
+    "@odata.type": "#AttributeRegistry.v1_3_3.AttributeRegistry",
+    "Description": "This registry defines a representation of Network Attribute instances",
+    "Id": "NetworkAttributesRegistry_NIC.Embedded.1-1-1",
+    "Language": "en",
+    "Name": "Network Attribute Registry",
+    "OwningEntity": "Dell",
+    "RegistryEntries": {
+        "Attributes": [
+            {
+                "AttributeName": "ChipMdl",
+                "CurrentValue": null,
+                "DisplayName": "Chip Type",
+                "DisplayOrder": 104,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 1024,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "PCIDeviceID",
+                "CurrentValue": null,
+                "DisplayName": "PCI Device ID",
+                "DisplayOrder": 105,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 1024,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "BusDeviceFunction",
+                "CurrentValue": null,
+                "DisplayName": "PCI Address",
+                "DisplayOrder": 106,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 1024,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "MacAddr",
+                "CurrentValue": null,
+                "DisplayName": "MAC Address",
+                "DisplayOrder": 108,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 17,
+                "MenuPath": "./",
+                "MinLength": 17,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "VirtMacAddr",
+                "CurrentValue": null,
+                "DisplayName": "Virtual MAC Address",
+                "DisplayOrder": 109,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "MaxLength": 17,
+                "MenuPath": "./",
+                "MinLength": 17,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": false,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": "^([0-9a-fA-F]{2}:){5}([0-9a-fA-F]{2})$",
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "FCoEOffloadSupport",
+                "CurrentValue": null,
+                "DisplayName": "FCoE Offload Support",
+                "DisplayOrder": 110,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 12,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "iSCSIOffloadSupport",
+                "CurrentValue": null,
+                "DisplayName": "iSCSI Offload Support",
+                "DisplayOrder": 111,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 12,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "iSCSIBootSupport",
+                "CurrentValue": null,
+                "DisplayName": "iSCSI Boot Support",
+                "DisplayOrder": 112,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 12,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "PXEBootSupport",
+                "CurrentValue": null,
+                "DisplayName": "PXE Boot Support",
+                "DisplayOrder": 113,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 12,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "FCoEBootSupport",
+                "CurrentValue": null,
+                "DisplayName": "FCoE Boot Support",
+                "DisplayOrder": 114,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 12,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "NicPartitioningSupport",
+                "CurrentValue": null,
+                "DisplayName": "NIC Partitioning Support",
+                "DisplayOrder": 115,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 12,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "FlexAddressing",
+                "CurrentValue": null,
+                "DisplayName": "FlexAddressing",
+                "DisplayOrder": 116,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 12,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "TXBandwidthControlMaximum",
+                "CurrentValue": null,
+                "DisplayName": "TX Bandwidth Control Maximum",
+                "DisplayOrder": 117,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 12,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "TXBandwidthControlMinimum",
+                "CurrentValue": null,
+                "DisplayName": "TX Bandwidth Control Minimum",
+                "DisplayOrder": 118,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 12,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "EnergyEfficientEthernet",
+                "CurrentValue": null,
+                "DisplayName": "Energy Efficient Ethernet (EEE)",
+                "DisplayOrder": 119,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 12,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "FamilyVersion",
+                "CurrentValue": null,
+                "DisplayName": "Family Firmware Version",
+                "DisplayOrder": 200,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 20,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Firmware Image Properties",
+                        "GroupName": "FrmwImgMenu"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "ControllerBIOSVersion",
+                "CurrentValue": null,
+                "DisplayName": "Controller BIOS Version",
+                "DisplayOrder": 201,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 16,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Firmware Image Properties",
+                        "GroupName": "FrmwImgMenu"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "EFIVersion",
+                "CurrentValue": null,
+                "DisplayName": "EFI Version",
+                "DisplayOrder": 202,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MaxLength": 16,
+                "MenuPath": "./",
+                "MinLength": 0,
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Firmware Image Properties",
+                        "GroupName": "FrmwImgMenu"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "String",
+                "ValueExpression": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "BlnkLeds",
+                "CurrentValue": null,
+                "DisplayName": "Blink LEDs",
+                "DisplayOrder": 102,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "LowerBound": 0,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": false,
+                "ResetRequired": true,
+                "ScalarIncrement": 0,
+                "Type": "Integer",
+                "UpperBound": 15,
+                "WarningText": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "BannerMessageTimeout",
+                "CurrentValue": null,
+                "DisplayName": "Banner Message Timeout",
+                "DisplayOrder": 304,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "LowerBound": 0,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "NIC Configuration",
+                        "GroupName": "NICConfig"
+                    }
+                },
+                "ReadOnly": false,
+                "ResetRequired": true,
+                "ScalarIncrement": 0,
+                "Type": "Integer",
+                "UpperBound": 15,
+                "WarningText": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "VLanId",
+                "CurrentValue": null,
+                "DisplayName": "Virtual LAN ID",
+                "DisplayOrder": 308,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "LowerBound": 1,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "NIC Configuration",
+                        "GroupName": "NICConfig"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "ScalarIncrement": 0,
+                "Type": "Integer",
+                "UpperBound": 4094,
+                "WarningText": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "EEEControl",
+                "CurrentValue": null,
+                "DisplayName": "Energy Efficient Ethernet",
+                "DisplayOrder": 103,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": false,
+                "ResetRequired": true,
+                "Type": "Enumeration",
+                "Value": [
+                    {
+                        "ValueDisplayName": "Disabled",
+                        "ValueName": "Disabled"
+                    },
+                    {
+                        "ValueDisplayName": "Maximum Power Savings",
+                        "ValueName": "Enabled"
+                    }
+                ],
+                "WarningText": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "LinkStatus",
+                "CurrentValue": null,
+                "DisplayName": "Link Status",
+                "DisplayOrder": 107,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": true,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "Main Configuration Page",
+                        "GroupName": "VndrConfigPage"
+                    }
+                },
+                "ReadOnly": true,
+                "ResetRequired": true,
+                "Type": "Enumeration",
+                "Value": [
+                    {
+                        "ValueDisplayName": "Disconnected",
+                        "ValueName": "Disconnected"
+                    },
+                    {
+                        "ValueDisplayName": "Connected",
+                        "ValueName": "Connected"
+                    }
+                ],
+                "WarningText": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "BootOptionROM",
+                "CurrentValue": null,
+                "DisplayName": "Option ROM",
+                "DisplayOrder": 300,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "NIC Configuration",
+                        "GroupName": "NICConfig"
+                    }
+                },
+                "ReadOnly": false,
+                "ResetRequired": true,
+                "Type": "Enumeration",
+                "Value": [
+                    {
+                        "ValueDisplayName": "Disabled",
+                        "ValueName": "Disabled"
+                    },
+                    {
+                        "ValueDisplayName": "Enabled",
+                        "ValueName": "Enabled"
+                    }
+                ],
+                "WarningText": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "LegacyBootProto",
+                "CurrentValue": null,
+                "DisplayName": "Legacy Boot Protocol",
+                "DisplayOrder": 301,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "NIC Configuration",
+                        "GroupName": "NICConfig"
+                    }
+                },
+                "ReadOnly": false,
+                "ResetRequired": true,
+                "Type": "Enumeration",
+                "Value": [
+                    {
+                        "ValueDisplayName": "PXE",
+                        "ValueName": "PXE"
+                    },
+                    {
+                        "ValueDisplayName": "None",
+                        "ValueName": "NONE"
+                    }
+                ],
+                "WarningText": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "BootStrapType",
+                "CurrentValue": null,
+                "DisplayName": "Boot Strap Type",
+                "DisplayOrder": 302,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "NIC Configuration",
+                        "GroupName": "NICConfig"
+                    }
+                },
+                "ReadOnly": false,
+                "ResetRequired": true,
+                "Type": "Enumeration",
+                "Value": [
+                    {
+                        "ValueDisplayName": "Auto Detect",
+                        "ValueName": "AutoDetect"
+                    },
+                    {
+                        "ValueDisplayName": "BBS",
+                        "ValueName": "BBS"
+                    },
+                    {
+                        "ValueDisplayName": "Int 18h",
+                        "ValueName": "Int18h"
+                    },
+                    {
+                        "ValueDisplayName": "Int 19h",
+                        "ValueName": "Int19h"
+                    }
+                ],
+                "WarningText": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "HideSetupPrompt",
+                "CurrentValue": null,
+                "DisplayName": "Hide Setup Prompt",
+                "DisplayOrder": 303,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "NIC Configuration",
+                        "GroupName": "NICConfig"
+                    }
+                },
+                "ReadOnly": false,
+                "ResetRequired": true,
+                "Type": "Enumeration",
+                "Value": [
+                    {
+                        "ValueDisplayName": "Disabled",
+                        "ValueName": "Disabled"
+                    },
+                    {
+                        "ValueDisplayName": "Enabled",
+                        "ValueName": "Enabled"
+                    }
+                ],
+                "WarningText": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "LnkSpeed",
+                "CurrentValue": null,
+                "DisplayName": "Link Speed",
+                "DisplayOrder": 305,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "NIC Configuration",
+                        "GroupName": "NICConfig"
+                    }
+                },
+                "ReadOnly": false,
+                "ResetRequired": true,
+                "Type": "Enumeration",
+                "Value": [
+                    {
+                        "ValueDisplayName": "Auto Negotiated",
+                        "ValueName": "AutoNeg"
+                    },
+                    {
+                        "ValueDisplayName": "10 Mbps Half",
+                        "ValueName": "10MbpsHalf"
+                    },
+                    {
+                        "ValueDisplayName": "10 Mbps Full",
+                        "ValueName": "10MbpsFull"
+                    },
+                    {
+                        "ValueDisplayName": "100 Mbps Half",
+                        "ValueName": "100MbpsHalf"
+                    },
+                    {
+                        "ValueDisplayName": "100 Mbps Full",
+                        "ValueName": "100MbpsFull"
+                    }
+                ],
+                "WarningText": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "WakeOnLan",
+                "CurrentValue": null,
+                "DisplayName": "Wake On LAN",
+                "DisplayOrder": 306,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "NIC Configuration",
+                        "GroupName": "NICConfig"
+                    }
+                },
+                "ReadOnly": false,
+                "ResetRequired": true,
+                "Type": "Enumeration",
+                "Value": [
+                    {
+                        "ValueDisplayName": "Disabled",
+                        "ValueName": "Disabled"
+                    },
+                    {
+                        "ValueDisplayName": "Enabled",
+                        "ValueName": "Enabled"
+                    }
+                ],
+                "WarningText": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "VLanMode",
+                "CurrentValue": null,
+                "DisplayName": "Virtual LAN Mode",
+                "DisplayOrder": 307,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "NIC Configuration",
+                        "GroupName": "NICConfig"
+                    }
+                },
+                "ReadOnly": false,
+                "ResetRequired": true,
+                "Type": "Enumeration",
+                "Value": [
+                    {
+                        "ValueDisplayName": "Disabled",
+                        "ValueName": "Disabled"
+                    },
+                    {
+                        "ValueDisplayName": "Enabled",
+                        "ValueName": "Enabled"
+                    }
+                ],
+                "WarningText": null,
+                "WriteOnly": false
+            },
+            {
+                "AttributeName": "PermitTotalPortShutdown",
+                "CurrentValue": null,
+                "DisplayName": "Permit Total Port Shutdown",
+                "DisplayOrder": 309,
+                "HelpText": null,
+                "Hidden": false,
+                "Immutable": false,
+                "MenuPath": "./",
+                "Oem": {
+                    "Dell": {
+                        "@odata.type": "#DellOemAttributeRegistry.v1_0_0.Attributes",
+                        "GroupDisplayName": "NIC Configuration",
+                        "GroupName": "NICConfig"
+                    }
+                },
+                "ReadOnly": false,
+                "ResetRequired": true,
+                "Type": "Enumeration",
+                "Value": [
+                    {
+                        "ValueDisplayName": "Disabled",
+                        "ValueName": "Disabled"
+                    },
+                    {
+                        "ValueDisplayName": "Enabled",
+                        "ValueName": "Enabled"
+                    }
+                ],
+                "WarningText": null,
+                "WriteOnly": false
+            }
+        ],
+        "Dependencies": [],
+        "Menus": []
+    },
+    "RegistryVersion": "1.0.0",
+    "SupportedSystems": [
+        {
+            "FirmwareVersion": "1.7.4",
+            "ProductName": "PowerEdge R750",
+            "SystemId": "451YFT3"
+        }
+    ]
+}
+"""
+RESPONSE_GET_NIC_ATTR_SPECIFIC = """\
+- INFO     - AttributeName: WakeOnLan
+- INFO     - CurrentValue: Enabled
+- INFO     - DisplayName: Wake On LAN
+- INFO     - DisplayOrder: 306
+- INFO     - HelpText: None
+- INFO     - Hidden: False
+- INFO     - Immutable: False
+- INFO     - MenuPath: ./
+- INFO     - Oem: {'Dell': {'@odata.type': '#DellOemAttributeRegistry.v1_0_0.Attributes', 'GroupDisplayName': 'NIC Configuration', 'GroupName': 'NICConfig'}}
+- INFO     - ReadOnly: False
+- INFO     - ResetRequired: True
+- INFO     - Type: Enumeration
+- INFO     - Value: [{'ValueDisplayName': 'Disabled', 'ValueName': 'Disabled'}, {'ValueDisplayName': 'Enabled', 'ValueName': 'Enabled'}]
+- INFO     - WarningText: None
+- INFO     - WriteOnly: False
+"""
+RESPONSE_GET_NIC_ATTR_SPECIFIC_VERSION_UNSUPPORTED = """\
+- ERROR    - Unsupported iDRAC version.
+- ERROR    - Was unable to get network attribute info.
+"""
+RESPONSE_GET_NIC_ATTR_SPECIFIC_REGISTRY_FAIL = """\
+- ERROR    - Was unable to get network attribute registry.
+- ERROR    - Was unable to get network attribute info.
+"""
+RESPONSE_GET_NIC_ATTR_SPECIFIC_LIST_FAIL = """\
+- ERROR    - Was unable to get NIC attribute(s) info, invalid server response.
+- ERROR    - Was unable to get network attribute info.
+"""

--- a/tests/test_nic_attributes.py
+++ b/tests/test_nic_attributes.py
@@ -1,0 +1,255 @@
+from asynctest import patch
+from tests.config import (
+    INIT_RESP,
+    INIT_RESP_SUPERMICRO,
+    GET_NIC_FQQDS_ADAPTERS,
+    GET_NIC_FQQDS_EMBEDDED,
+    GET_NIC_FQQDS_INTEGRATED,
+    GET_NIC_FQQDS_SLOT,
+    RESPONSE_GET_NIC_FQQDS_OK,
+    RESPONSE_GET_NIC_FQQDS_UNSUPPORTED,
+    RESPONSE_GET_NIC_FQQDS_INVALID,
+    GET_NIC_ATTR_LIST,
+    RESPONSE_GET_NIC_ATTR_LIST_OK,
+    RESPONSE_GET_NIC_ATTR_LIST_UNSUPPORTED,
+    RESPONSE_GET_NIC_ATTR_LIST_INVALID,
+    GET_FW_VERSION,
+    GET_FW_VERSION_UNSUPPORTED,
+    GET_NIC_ATTR_REGISTRY,
+    RESPONSE_GET_NIC_ATTR_SPECIFIC,
+    RESPONSE_GET_NIC_ATTR_SPECIFIC_VERSION_UNSUPPORTED,
+    RESPONSE_GET_NIC_ATTR_SPECIFIC_REGISTRY_FAIL,
+    RESPONSE_GET_NIC_ATTR_SPECIFIC_LIST_FAIL,
+)
+from tests.test_base import TestBase
+
+
+class TestNICFQDDs(TestBase):
+    option_arg = "--get-nic-fqdds"
+
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.get")
+    def test_get_nic_fqdds_ok(self, mock_get, mock_post, mock_delete):
+        responses = INIT_RESP + [
+            GET_NIC_FQQDS_ADAPTERS,
+            GET_NIC_FQQDS_EMBEDDED,
+            GET_NIC_FQQDS_INTEGRATED,
+            GET_NIC_FQQDS_SLOT,
+        ]
+        self.set_mock_response(mock_get, 200, responses)
+        self.set_mock_response(mock_post, 200, "OK")
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = [
+            self.option_arg,
+        ]
+        _, err = self.badfish_call()
+        assert err == RESPONSE_GET_NIC_FQQDS_OK
+
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.get")
+    def test_get_nic_fqdds_unsupported(self, mock_get, mock_post, mock_delete):
+        responses = INIT_RESP + ["{}"]
+        self.set_mock_response(mock_get, [200, 200, 200, 200, 200, 404], responses)
+        self.set_mock_response(mock_post, 200, "OK")
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = [
+            self.option_arg,
+        ]
+        _, err = self.badfish_call()
+        assert err == RESPONSE_GET_NIC_FQQDS_UNSUPPORTED
+
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.get")
+    def test_get_nic_fqdds_unsupported(self, mock_get, mock_post, mock_delete):
+        responses = INIT_RESP + ["{}"]
+        self.set_mock_response(mock_get, 200, responses)
+        self.set_mock_response(mock_post, 200, "OK")
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = [
+            self.option_arg,
+        ]
+        _, err = self.badfish_call()
+        assert err == RESPONSE_GET_NIC_FQQDS_INVALID
+
+
+class TestGetNICAttribute(TestBase):
+    option_arg = "--get-nic-attribute"
+
+    # LIST ALL ATTRIBUTES FOR A NIC
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.get")
+    def test_get_nic_attr_list_ok(self, mock_get, mock_post, mock_delete):
+        responses = INIT_RESP + [
+            GET_NIC_ATTR_LIST,
+        ]
+        self.set_mock_response(mock_get, 200, responses)
+        self.set_mock_response(mock_post, 200, "OK")
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = [
+            self.option_arg,
+            "NIC.Embedded.1-1-1",
+        ]
+        _, err = self.badfish_call()
+        assert err == RESPONSE_GET_NIC_ATTR_LIST_OK
+
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.get")
+    def test_get_nic_attr_list_unsupported(self, mock_get, mock_post, mock_delete):
+        responses = INIT_RESP + ["{}"]
+        self.set_mock_response(mock_get, [200, 200, 200, 200, 200, 404], responses)
+        self.set_mock_response(mock_post, 200, "OK")
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = [
+            self.option_arg,
+            "NIC.Embedded.1-1-1",
+        ]
+        _, err = self.badfish_call()
+        assert err == RESPONSE_GET_NIC_ATTR_LIST_UNSUPPORTED
+
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.get")
+    def test_get_nic_attr_list_invalid(self, mock_get, mock_post, mock_delete):
+        responses = INIT_RESP + ["{}"]
+        self.set_mock_response(mock_get, 200, responses)
+        self.set_mock_response(mock_post, 200, "OK")
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = [
+            self.option_arg,
+            "NIC.Embedded.1-1-1",
+        ]
+        _, err = self.badfish_call()
+        assert err == RESPONSE_GET_NIC_ATTR_LIST_INVALID
+
+    # LIST INFO ABOUT A SPECIFIC ATTRIBUTE
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.get")
+    def test_get_nic_attr_info_ok(self, mock_get, mock_post, mock_delete):
+        responses = INIT_RESP + [
+            GET_FW_VERSION,
+            GET_NIC_ATTR_REGISTRY,
+            GET_NIC_ATTR_LIST
+        ]
+        self.set_mock_response(mock_get, 200, responses)
+        self.set_mock_response(mock_post, 200, "OK")
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = [
+            self.option_arg,
+            "NIC.Embedded.1-1-1",
+            "--attribute",
+            "WakeOnLan"
+        ]
+        _, err = self.badfish_call()
+        assert err == RESPONSE_GET_NIC_ATTR_SPECIFIC
+
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.get")
+    def test_get_nic_attr_info_vendor_unsupported(self, mock_get, mock_post, mock_delete):
+        responses = INIT_RESP_SUPERMICRO + [
+            GET_FW_VERSION,
+        ]
+        self.set_mock_response(mock_get, 200, responses)
+        self.set_mock_response(mock_post, 200, "OK")
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = [
+            self.option_arg,
+            "NIC.Embedded.1-1-1",
+            "--attribute",
+            "WakeOnLan"
+        ]
+        _, err = self.badfish_call()
+        assert err == RESPONSE_GET_NIC_FQQDS_UNSUPPORTED
+
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.get")
+    def test_get_nic_attr_info_version_unsupported(self, mock_get, mock_post, mock_delete):
+        responses = INIT_RESP + [
+            GET_FW_VERSION_UNSUPPORTED,
+        ]
+        self.set_mock_response(mock_get, 200, responses)
+        self.set_mock_response(mock_post, 200, "OK")
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = [
+            self.option_arg,
+            "NIC.Embedded.1-1-1",
+            "--attribute",
+            "WakeOnLan"
+        ]
+        _, err = self.badfish_call()
+        assert err == RESPONSE_GET_NIC_ATTR_SPECIFIC_VERSION_UNSUPPORTED
+
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.get")
+    def test_get_nic_attr_info_registry_fail(self, mock_get, mock_post, mock_delete):
+        responses = INIT_RESP + [
+            GET_FW_VERSION,
+            "{}"
+        ]
+        self.set_mock_response(mock_get, [200, 200, 200, 200, 200, 200, 404], responses)
+        self.set_mock_response(mock_post, 200, "OK")
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = [
+            self.option_arg,
+            "NIC.Embedded.1-1-1",
+            "--attribute",
+            "WakeOnLan"
+        ]
+        _, err = self.badfish_call()
+        assert err == RESPONSE_GET_NIC_ATTR_SPECIFIC_REGISTRY_FAIL
+
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.get")
+    def test_get_nic_attr_info_registry_empty(self, mock_get, mock_post, mock_delete):
+        responses = INIT_RESP + [
+            GET_FW_VERSION,
+            "{}"
+        ]
+        self.set_mock_response(mock_get, 200, responses)
+        self.set_mock_response(mock_post, 200, "OK")
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = [
+            self.option_arg,
+            "NIC.Embedded.1-1-1",
+            "--attribute",
+            "WakeOnLan"
+        ]
+        _, err = self.badfish_call()
+        assert err == RESPONSE_GET_NIC_ATTR_SPECIFIC_REGISTRY_FAIL
+
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.get")
+    def test_get_nic_attr_info_list_empty(self, mock_get, mock_post, mock_delete):
+        responses = INIT_RESP + [
+            GET_FW_VERSION,
+            GET_NIC_ATTR_REGISTRY,
+            "{}",
+        ]
+        self.set_mock_response(mock_get, 200, responses)
+        self.set_mock_response(mock_post, 200, "OK")
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = [
+            self.option_arg,
+            "NIC.Embedded.1-1-1",
+            "--attribute",
+            "WakeOnLan"
+        ]
+        _, err = self.badfish_call()
+        assert err == RESPONSE_GET_NIC_ATTR_SPECIFIC_LIST_FAIL
+
+
+class TestSetNICAttribute(TestBase):
+    option_arg = "--set-nic-attribute"
+    # TODO: Fix after iDRAC version update.
+
+    pass


### PR DESCRIPTION
connected to: #385 

After extensive testing on my part and a joint investigation with @grafuls, this feature cannot be fully implemented in the current state of our lab, because of our iDRAC setup/versions.
Getting a list of attributes for specific NICs is working as it should along with getting information about a specific attribute. (The same way as we do it for BIOS attributes.)
Setting attributes though does not work, even if the somewhat incomplete feeling [iDRAC documentation about this use case](https://developer.dell.com/apis/2978/versions/5.xx/openapi.yaml/paths/~1redfish~1v1~1Chassis~1%7BComputerSystemId%7D~1NetworkAdapters~1%7BNetworkId%7D~1NetworkDeviceFunctions~1%7BNetworkDeviceFunctionId%7D~1Oem~1Dell~1DellNetworkAttributes~1%7BNetworkAttributesId%7D~1Settings/patch) says it should for versions 5.x.x.x (testing was done against 5.10.50.0 as the newest version available to us).
Neither my attempt at solving this or the [reference script from Dell](https://github.com/dell/iDRAC-Redfish-Scripting/blob/master/Redfish%20Python/GetSetOemNetworkDevicePropertiesREDFISH.py) works.
In our case the end-point accepting the setting of attributes shows no supported attributes to set.

The getting functionality was implemented and tested. The setting of attributes was made as a draft implementation supposed to completed in the future, when the environment will allow for it.