### PR TITLE
fix: default for custom device types on idrac_interfaces

### DIFF
--- a/config/idrac_interfaces.yml
+++ b/config/idrac_interfaces.yml
@@ -4,86 +4,88 @@
 # Also see /opt/quads/quads/config.py SUPPORTED list if adding system types.
 #
 ---
-director_b01_fc640_interfaces: NIC.ChassisSlot.8-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-director_b02_fc640_interfaces: NIC.ChassisSlot.4-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-director_b03_fc640_interfaces: NIC.ChassisSlot.6-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-director_b04_fc640_interfaces: NIC.ChassisSlot.2-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-director_r630_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Slot.2-1-1
-director_r640_interfaces: NIC.Slot.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-director_r650_interfaces: NIC.Slot.1-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-director_r660_interfaces: NIC.PxeDevice.2-1,RAID.SL.3-2,NIC.PxeDevice.1-1
-director_r720xd_interfaces: NIC.Slot.4-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
-director_r730xd_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
-director_740xd_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,NIC.Integrated.1-3-1,HardDisk.List.1-1
-director_r740xd_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
-director_r750_interfaces: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-director_7425_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,NIC.Integrated.1-3-1,HardDisk.List.1-1
-director_7525_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,NIC.Embedded.1-1-1,HardDisk.List.1-1
-director_r930_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
-foreman_b01_fc640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.ChassisSlot.8-1-1
-foreman_b02_fc640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.ChassisSlot.4-1-1
-foreman_b03_fc640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.ChassisSlot.6-1-1
-foreman_b04_fc640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.ChassisSlot.2-1-1
-foreman_r630_interfaces: NIC.Slot.2-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
-foreman_r640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.1-2-1
-foreman_r650_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.1-1-1
-foreman_r660_interfaces: NIC.PxeDevice.1-1,RAID.SL.3-2,NIC.PxeDevice.2-1
-foreman_r720xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Slot.4-2-1
-foreman_r730xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
-foreman_740xd_interfaces: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
-foreman_r740xd_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-foreman_r750_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1-1
-foreman_7425_interfaces: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1
-foreman_7525_interfaces: NIC.Embedded.1-1-1,NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,HardDisk.List.1-1
-foreman_r930_interfaces: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
+director_b01_fc640: NIC.ChassisSlot.8-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+director_b02_fc640: NIC.ChassisSlot.4-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+director_b03_fc640: NIC.ChassisSlot.6-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+director_b04_fc640: NIC.ChassisSlot.2-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+director_r630: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Slot.2-1-1
+director_r640: NIC.Slot.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+director_r650: NIC.Slot.1-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+director_r660: NIC.PxeDevice.2-1,RAID.SL.3-2,NIC.PxeDevice.1-1
+director_r720xd: NIC.Slot.4-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
+director_r730xd: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
+director_740xd: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,NIC.Integrated.1-3-1,HardDisk.List.1-1
+director_r740xd: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
+director_r750: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+director_7425: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,NIC.Integrated.1-3-1,HardDisk.List.1-1
+director_7525: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,NIC.Embedded.1-1-1,HardDisk.List.1-1
+director_r930: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
+foreman_b01_fc640: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.ChassisSlot.8-1-1
+foreman_b02_fc640: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.ChassisSlot.4-1-1
+foreman_b03_fc640: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.ChassisSlot.6-1-1
+foreman_b04_fc640: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.ChassisSlot.2-1-1
+foreman_r630: NIC.Slot.2-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
+foreman_r640: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.1-2-1
+foreman_r650: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.1-1-1
+foreman_r660: NIC.PxeDevice.1-1,RAID.SL.3-2,NIC.PxeDevice.2-1
+foreman_r720xd: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Slot.4-2-1
+foreman_r730xd: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
+foreman_740xd: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
+foreman_r740xd: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+foreman_r750: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1-1
+foreman_7425: NIC.Integrated.1-3-1,NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,HardDisk.List.1-1
+foreman_7525: NIC.Embedded.1-1-1,NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,HardDisk.List.1-1
+foreman_r930: NIC.Integrated.1-3-1,HardDisk.List.1-1,NIC.Integrated.1-2-1
 # These are for EFI
 # Expanding rest of models as a workaround for issue #239
-uefi_r630_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Slot.2-1-1
-uefi_r640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.1-1-1
-uefi_b01_fc640_interfaces: NIC.ChassisSlot.8-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-uefi_b02_fc640_interfaces: NIC.ChassisSlot.4-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-uefi_b03_fc640_interfaces: NIC.ChassisSlot.6-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-uefi_b04_fc640_interfaces: NIC.ChassisSlot.2-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-uefi_r650_interfaces: NIC.Slot.1-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+uefi_r630: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Slot.2-1-1
+uefi_r640: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.1-1-1
+uefi_b01_fc640: NIC.ChassisSlot.8-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+uefi_b02_fc640: NIC.ChassisSlot.4-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+uefi_b03_fc640: NIC.ChassisSlot.6-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+uefi_b04_fc640: NIC.ChassisSlot.2-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+uefi_r650: NIC.Slot.1-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
 # Here we should be able to distinguish between 'foreman' and 'director'
 # interface layouts.
-uefi_r720xd_interfaces: NIC.Slot.4-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
-uefi_r730xd_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
-uefi_740xd_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,NIC.Integrated.1-3-1,HardDisk.List.1-1
-uefi_r740xd_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
-uefi_r750_interfaces: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-uefi_7425_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,NIC.Integrated.1-3-1,HardDisk.List.1-1
-uefi_7525_interfaces: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,NIC.Embedded.1-1-1,HardDisk.List.1-1
-uefi_r930_interfaces: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
-uefi_mx750c_interfaces: NIC.PxeDevice.1-1,RAID.SL.3-2
+uefi_r720xd: NIC.Slot.4-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
+uefi_r730xd: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
+uefi_740xd: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,NIC.Integrated.1-3-1,HardDisk.List.1-1
+uefi_r740xd: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
+uefi_r750: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+uefi_7425: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.7-2-1,NIC.Slot.7-1-1,NIC.Integrated.1-3-1,HardDisk.List.1-1
+uefi_7525: NIC.Integrated.1-1-1,NIC.Integrated.1-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,NIC.Embedded.1-1-1,HardDisk.List.1-1
+uefi_r930: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-3-1
+uefi_mx750c: NIC.PxeDevice.1-1,RAID.SL.3-2
 
 # To understand how custom overrides and hierarchy work please see https://github.com/redhat-performance/badfish#host-type-overrides
 # PerfLab Entries
-foreman_cc37_r750_interfaces: NIC.Embedded.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1-1
-director_cc37_r750_interfaces: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Embedded.1-1-1
-foreman_bb37_r750_interfaces: NIC.Embedded.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1-1
-director_bb37_r750_interfaces: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Embedded.1-1-1
-foreman_r760_interfaces: NIC.PxeDevice.1-1,RAID.SL.3-2
-director_r760_interfaces: RAID.SL.3-2,NIC.PxeDevice.1-1
-foreman_mx750c_interfaces: NIC.PxeDevice.1-1,RAID.SL.3-2
-director_mx750c_interfaces: RAID.SL.3-2,NIC.PxeDevice.1-1
+foreman_cc37_r750: NIC.Embedded.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1-1
+director_cc37_r750: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Embedded.1-1-1
+foreman_bb37_r750: NIC.Embedded.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1-1
+director_bb37_r750: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Embedded.1-1-1
+foreman_r760: NIC.PxeDevice.1-1,RAID.SL.3-2
+director_r760: RAID.SL.3-2,NIC.PxeDevice.1-1
+foreman_mx750c: NIC.PxeDevice.1-1,RAID.SL.3-2
+director_mx750c: RAID.SL.3-2,NIC.PxeDevice.1-1
 
 # Custom Rack F04
-director_f18_r640_interfaces: NIC.Slot.3-2,HardDisk.List.1-1,NIC.Slot.3-1,NIC.Slot.2-1,NIC.Slot.2-2,NIC.Integrated.1-1-1
-foreman_f18_r640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1,NIC.Slot.3-2,NIC.Slot.2-1,NIC.Slot.2-2
+director_f18_r640: NIC.Slot.3-2,HardDisk.List.1-1,NIC.Slot.3-1,NIC.Slot.2-1,NIC.Slot.2-2,NIC.Integrated.1-1-1
+foreman_f18_r640: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.3-1,NIC.Slot.3-2,NIC.Slot.2-1,NIC.Slot.2-2
 
 # Custom Rack E27 and E28 for Dell R750
-director_e27_r750_interfaces: NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,NIC.Embedded.1-1-1,HardDisk.List.1-1
-director_e28_r750_interfaces: NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,NIC.Embedded.1-1-1,HardDisk.List.1-1
-foreman_e27_r750_interfaces: NIC.Embedded.1-1-1,NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,HardDisk.List.1-1
-foreman_e28_r750_interfaces: NIC.Embedded.1-1-1,NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,HardDisk.List.1-1
-uefi_e27_r750_interfaces: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Embedded.1-1-1
-uefi_e28_r750_interfaces: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Embedded.1-1-1
+director_e27_r750: NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,NIC.Embedded.1-1-1,HardDisk.List.1-1
+director_e28_r750: NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,NIC.Embedded.1-1-1,HardDisk.List.1-1
+foreman_e27_r750: NIC.Embedded.1-1-1,NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,HardDisk.List.1-1
+foreman_e28_r750: NIC.Embedded.1-1-1,NIC.Slot.3-1-1,NIC.Slot.3-2-1,NIC.Slot.6-1-1,NIC.Slot.6-2-1,HardDisk.List.1-1
+uefi_e27_r750: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Embedded.1-1-1
+uefi_e28_r750: NIC.Slot.3-1-1,HardDisk.List.1-1,NIC.Embedded.1-1-1
 
 ## Custom F04 specific overrides (examples)
 ## h34 (should resemble other r640 hosts)
-# director_f04_h34_r640_interfaces: NIC.Slot.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-# foreman_f04_h34_r640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.1-2-1
+# director_f04_h34_r640: NIC.Slot.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+# foreman_f04_h34_r640: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.1-2-1
 #  h35 (should resemble other r640 hosts)
-# director_f04_h35_r640_interfaces: NIC.Slot.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
-# foreman_f04_h35_r640_interfaces: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.1-2-1
+# director_f04_h35_r640: NIC.Slot.1-2-1,HardDisk.List.1-1,NIC.Integrated.1-1-1
+# foreman_f04_h35_r640: NIC.Integrated.1-1-1,HardDisk.List.1-1,NIC.Slot.1-2-1
+
+custom: NIC.Integrated.1-2-1,HardDisk.List.1-1,NIC.Slot.2-1-1

--- a/src/badfish/helpers/logger.py
+++ b/src/badfish/helpers/logger.py
@@ -53,13 +53,52 @@ class BadfishHandler(StreamHandler):
         try:
             if self.host:
                 host_name = self.host.strip().split(".")[0]
-                new_dict = yaml.safe_load(self.messages[host_name])
+                # Ensure the message is properly formatted as YAML by wrapping values in quotes
+                message = self.messages[host_name]
+                # Try to parse as is first
+                try:
+                    new_dict = yaml.safe_load(message)
+                except yaml.YAMLError:
+                    # If parsing fails, try to format the value as a quoted string
+                    lines = message.strip().split('\n')
+                    formatted_lines = []
+                    for line in lines:
+                        if ':' in line:
+                            key, value = line.split(':', 1)
+                            value = value.strip()
+                            # If value contains spaces or special characters, wrap in quotes
+                            if ' ' in value or any(c in value for c in '{}[](),:#'):
+                                value = f'"{value}"'
+                            formatted_lines.append(f"{key}: {value}")
+                        else:
+                            formatted_lines.append(line)
+                    formatted_message = '\n'.join(formatted_lines)
+                    new_dict = yaml.safe_load(formatted_message)
+                
                 self.output_dict.update({self.host: new_dict.copy()})
                 self.host = None
             else:
-                new_dict = yaml.safe_load(self.messages["badfish.helpers.logger"])
+                message = self.messages["badfish.helpers.logger"]
+                # Apply the same formatting logic for non-host messages
+                try:
+                    new_dict = yaml.safe_load(message)
+                except yaml.YAMLError:
+                    lines = message.strip().split('\n')
+                    formatted_lines = []
+                    for line in lines:
+                        if ':' in line:
+                            key, value = line.split(':', 1)
+                            value = value.strip()
+                            if ' ' in value or any(c in value for c in '{}[](),:#'):
+                                value = f'"{value}"'
+                            formatted_lines.append(f"{key}: {value}")
+                        else:
+                            formatted_lines.append(line)
+                    formatted_message = '\n'.join(formatted_lines)
+                    new_dict = yaml.safe_load(formatted_message)
+                
                 self.output_dict.update(new_dict.copy())
-        except yaml.YAMLError:
+        except yaml.YAMLError as ex:
             self.output_dict = {"unsupported_command": True}
 
     def diff(self):

--- a/tests/config.py
+++ b/tests/config.py
@@ -97,7 +97,11 @@ RESPONSE_BOOT_TO = (
     f"- WARNING  - Job queue already cleared for iDRAC {MOCK_HOST}, DELETE command will not execute.\n"
     "- INFO     - Command passed to set BIOS attribute pending values.\n"
 )
-RESPONSE_BOOT_TO_BAD_TYPE = "- ERROR    - Expected values for -t argument are: ['director', 'foreman', 'uefi']\n"
+RESPONSE_BOOT_TO_CUSTOM = (
+    f"- WARNING  - Job queue already cleared for iDRAC host01.example.com, DELETE command will not execute.\n"
+    "- INFO     - Command passed to set BIOS attribute pending values.\n"
+)
+RESPONSE_BOOT_TO_BAD_TYPE = "- ERROR    - Expected values for -t argument are: ['custom', 'director', 'foreman', 'uefi']\n"
 RESPONSE_BOOT_TO_SERVICE_UNAVAILABLE = (
     f"- WARNING  - Job queue already cleared for iDRAC {MOCK_HOST}, DELETE command will not execute.\n"
     "- ERROR    - Command failed, error code is: 503.\n"
@@ -216,7 +220,7 @@ RESPONSE_CHANGE_BOOT_UEFI = (
     "- INFO     - Polling for host state: Not Down\n"
     "- INFO     - Command passed to On server, code return is 200.\n"
 )
-RESPONSE_CHANGE_BAD_TYPE = "- ERROR    - Expected values for -t argument are: ['director', 'foreman', 'uefi']\n"
+RESPONSE_CHANGE_BAD_TYPE = "- ERROR    - Expected values for -t argument are: ['custom', 'director', 'foreman', 'uefi']\n"
 RESPONSE_CHANGE_TO_SAME = "- WARNING  - No changes were made since the boot order already matches the requested.\n"
 RESPONSE_CHANGE_NO_INT = "- ERROR    - You must provide a path to the interfaces yaml via `-i` optional argument.\n"
 

--- a/tests/test_boot_to_type.py
+++ b/tests/test_boot_to_type.py
@@ -4,7 +4,7 @@ from tests.config import (BLANK_RESP, BOOT_MODE_RESP, BOOT_SEQ_RESP,
                           BOOT_SEQ_RESPONSE_DIRECTOR, INIT_RESP,
                           INTERFACES_PATH, JOB_OK_RESP, RESET_TYPE_RESP,
                           RESPONSE_BOOT_TO, RESPONSE_BOOT_TO_BAD_FILE,
-                          RESPONSE_BOOT_TO_BAD_TYPE, RESPONSE_BOOT_TO_NO_FILE,
+                          RESPONSE_BOOT_TO_BAD_TYPE, RESPONSE_BOOT_TO_CUSTOM, RESPONSE_BOOT_TO_NO_FILE,
                           STATE_ON_RESP)
 from tests.test_base import TestBase
 
@@ -35,6 +35,30 @@ class TestBootTo(TestBase):
         self.args = ["-i", INTERFACES_PATH, self.option_arg, "foreman"]
         _, err = self.badfish_call()
         assert err == RESPONSE_BOOT_TO
+
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.patch")
+    @patch("aiohttp.ClientSession.get")
+    def test_boot_to_type_custom(self, mock_get, mock_patch, mock_post, mock_delete):
+        boot_seq_resp_fmt = BOOT_SEQ_RESP % str(BOOT_SEQ_RESPONSE_DIRECTOR)
+        get_resp = [
+            BOOT_MODE_RESP,
+            boot_seq_resp_fmt.replace("'", '"'),
+            BLANK_RESP,
+            BOOT_MODE_RESP,
+            RESET_TYPE_RESP,
+            STATE_ON_RESP,
+            STATE_ON_RESP,
+        ]
+        responses = INIT_RESP + get_resp
+        self.set_mock_response(mock_get, 200, responses)
+        self.set_mock_response(mock_patch, 200, ["OK"])
+        self.set_mock_response(mock_post, 200, JOB_OK_RESP)
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = ["-i", INTERFACES_PATH, self.option_arg, "custom"]
+        _, err = self.badfish_call(mock_host="host01.example.com")
+        assert err == RESPONSE_BOOT_TO_CUSTOM
 
     @patch("aiohttp.ClientSession.delete")
     @patch("aiohttp.ClientSession.post")


### PR DESCRIPTION
closes: https://github.com/redhat-performance/badfish/issues/446