### PR TITLE
fix: event_loop for strict Py314 and beyond.

### DIFF
--- a/src/badfish/main.py
+++ b/src/badfish/main.py
@@ -2674,7 +2674,11 @@ def main(argv=None):
     output = _args["output"]
     bfl = BadfishLogger(_args["verbose"], multi_host, _args["log"], output)
 
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     tasks = []
     host_order = {}
     if host_list:

--- a/tests/test_async_loop.py
+++ b/tests/test_async_loop.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from badfish.main import main
+
+
+class TestAsyncioFix(unittest.TestCase):
+    @patch('badfish.main.execute_badfish')
+    @patch('badfish.main.BadfishLogger')
+    @patch('badfish.main.parse_arguments')
+    @patch('asyncio.set_event_loop')
+    @patch('asyncio.new_event_loop')
+    @patch('asyncio.get_event_loop')
+    def test_main_handles_no_event_loop(self, mock_get_loop, mock_new_loop,
+                                        mock_set_loop, mock_parse_args,
+                                        mock_logger, mock_execute):
+        mock_get_loop.side_effect = RuntimeError("No event loop")
+
+        mock_loop_instance = MagicMock()
+        mock_new_loop.return_value = mock_loop_instance
+        mock_loop_instance.run_until_complete.return_value = ("localhost", True)
+
+        mock_parse_args.return_value = {
+            "verbose": False, "host": "localhost", "delta": None,
+            "firmware_inventory": None, "host_list": None, "log": None,
+            "output": None
+        }
+
+        main()
+
+        mock_get_loop.assert_called_once()
+        mock_new_loop.assert_called_once()
+        mock_set_loop.assert_called_once_with(mock_loop_instance)
+        mock_loop_instance.run_until_complete.assert_called()
+
+    @patch('badfish.main.execute_badfish')
+    @patch('badfish.main.BadfishLogger')
+    @patch('badfish.main.parse_arguments')
+    @patch('asyncio.set_event_loop')
+    @patch('asyncio.new_event_loop')
+    @patch('asyncio.get_event_loop')
+    def test_main_uses_existing_loop(self, mock_get_loop, mock_new_loop,
+                                     mock_set_loop, mock_parse_args,
+                                     mock_logger, mock_execute):
+        existing_loop = MagicMock()
+        mock_get_loop.return_value = existing_loop
+        mock_get_loop.side_effect = None
+        existing_loop.run_until_complete.return_value = ("localhost", True)
+
+        mock_parse_args.return_value = {
+            "verbose": False, "host": "localhost", "delta": None,
+            "firmware_inventory": None, "host_list": None, "log": None,
+            "output": None
+        }
+
+        main()
+
+        mock_get_loop.assert_called_once()
+        mock_new_loop.assert_not_called()
+        mock_set_loop.assert_not_called()
+        existing_loop.run_until_complete.assert_called()


### PR DESCRIPTION
In recent Python versions (especially 3.10+, with further tighness and deprecations in 3.14), asyncio.get_event_loop() no longer implicitly creates a loop when none exists in the current thread — it raises RuntimeError instead (and in some cases deprecations/warnings apply to related policy functions like set_event_loop or get_event_loop_policy).

"The get_event_loop() method of the default asyncio policy now emits a DeprecationWarning if there is no current event loop set and it decides to create one. In some future Python release [3.14], this will become an error."

fixes: https://github.com/redhat-performance/badfish/issues/480